### PR TITLE
chore(): Make it compatible with angular-cli

### DIFF
--- a/ng2-bootstrap.ts
+++ b/ng2-bootstrap.ts
@@ -1,3 +1,18 @@
+import {Accordion, AccordionPanel} from './components/accordion';
+import {Alert} from './components/alert';
+import {ButtonCheckbox, ButtonRadio} from './components/buttons';
+import {Carousel, Slide} from './components/carousel';
+import {Collapse} from './components/collapse';
+import {DatePicker} from './components/datepicker';
+import {Dropdown} from './components/dropdown';
+import {Pagination, Pager} from './components/pagination';
+import {Progressbar, Progress} from './components/progressbar';
+import {Rating} from './components/rating';
+import {Tabset, Tab, TabHeading} from './components/tabs';
+import {Timepicker} from './components/timepicker';
+import {Tooltip} from './components/tooltip';
+import {Typeahead} from './components/typeahead';
+
 export * from  './components/accordion';
 export * from  './components/alert';
 export * from  './components/buttons';
@@ -16,3 +31,24 @@ export * from  './components/typeahead';
 export * from  './components/position'
 export * from  './components/common'
 export * from  './components/ng2-bootstrap-config';
+
+export default {
+  directives: [Dropdown, Progress, Tab, TabHeading],
+  components: [
+    Accordion,
+    AccordionPanel,
+    ButtonCheckbox,
+    ButtonRadio,
+    Carousel,
+    Slide,
+    Collapse,
+    DatePicker,
+    Pagination,
+    Pager,
+    Rating,
+    Tabset,
+    Timepicker,
+    Tooltip,
+    Typeahead
+  ]
+}


### PR DESCRIPTION
Wow, this is huge! Thanks authors for this libraries.
I added default exports to be compatible with [angular-cli](https://github.com/angular/angular-cli)  `ng install ng2-bootstrap` command, you can checkout [documentation](https://github.com/angular/angular-cli/pull/173) about it. 
I go through all components/directives and I hope I didn't miss anything. 
I noticed you already have a bundler script which is needed to be compatible with `angular-cli`, so if this will be merged, this library will be completely compatible with `angular-cli`.
