### PR TITLE
Typeahead MinLength=0

### DIFF
--- a/components/typeahead/readme.md
+++ b/components/typeahead/readme.md
@@ -40,7 +40,7 @@ export class Typeahead implements OnInit {
 
   - `ngModel` (`string`) - binds to string user's input
   - `typeahead` (`any`) - options source, can be Array of strings or objects or function that return Promise for external matching process
-  - `typeaheadMinLength` (`?number=1`) - minimal no of characters that needs to be entered before typeahead kicks-in. Must be greater than or equal to 1.
+  - `typeaheadMinLength` (`?number=1`) - minimal no of characters that needs to be entered before typeahead kicks-in. When set to 0, typeahead shows on focus with full list of options (limited as normal by typeaheadOptionsLimit)
   - `typeaheadWaitMs` (`?number=0`) - minimal wait time after last character typed before typeahead kicks-in
   - `typeaheadOptionsLimit` (`?number=20`) - maximum length of options items list
   - `typeaheadOptionField` (`?string`) - name of field in array of states that contain options as objects, we use array item as option in case of this field is missing

--- a/components/typeahead/typeahead.directive.ts
+++ b/components/typeahead/typeahead.directive.ts
@@ -90,7 +90,7 @@ export class Typeahead implements OnInit {
         this.debouncer();
       }
 
-      if (this.typeaheadAsync === false) {
+      if (!this.typeaheadAsync) {
         this.processMatches();
         this.finalizeAsyncCall();
       }
@@ -109,7 +109,7 @@ export class Typeahead implements OnInit {
         this.debouncer();
       }
 
-      if (this.typeaheadAsync === false) {
+      if (!this.typeaheadAsync) {
         this.processMatches();
         this.finalizeAsyncCall();
       }
@@ -283,7 +283,7 @@ export class Typeahead implements OnInit {
     }
 
     if (!this.cd.model) {
-      for (let i = 0; i < this.typeahead.length; i++) {
+      for (let i = 0; i < Math.min(this.typeaheadOptionsLimit, this.typeahead.length); i++) {
         this._matches.push(this.typeahead[i]);
       }
       return;


### PR DESCRIPTION
Made it possible to use the TypeaheadMinLength feature with value=0. This will show the entire list of options as soon as the 'focus' event is fired and also when you remove all text.

Would add feature for https://github.com/valor-software/ng2-bootstrap/issues/413
