### PR TITLE
Adding index property to tab component

### DIFF
--- a/components/tabs/readme.md
+++ b/components/tabs/readme.md
@@ -33,6 +33,7 @@ export class TabDirective implements OnInit, OnDestroy, DoCheck {
   @Input() public heading:string;
   @Input() public disabled:boolean;
   @Input() public removable:boolean;
+  @Input() public index:number = 0;
 
   /** tab active state toogle */
   @HostBinding('class.active')
@@ -58,6 +59,7 @@ export class TabHeadingDirective {}
   - `active` (`?boolean=false`) - if tab is active equals true, or set `true` to activate tab
   - `disabled` (`?boolean=false`) - if `true` tab can not be activated
   - `removable` (`?boolean=false`) - if `true` tab can be removable, additional button will appear
+  - `index` (`?number=0`) - tab order in which they are displayed
 
 ### Tab events
   - `select` - fired when `tab` became active, `$event:Tab` equals to selected instance of `Tab` component

--- a/components/tabs/tab.directive.ts
+++ b/components/tabs/tab.directive.ts
@@ -11,6 +11,7 @@ export class TabDirective implements OnDestroy {
   @Input() public heading:string;
   @Input() public disabled:boolean;
   @Input() public removable:boolean;
+  @Input() public index:number = 0;
 
   /** tab active state toggle */
   @HostBinding('class.active')

--- a/components/tabs/tabset.component.ts
+++ b/components/tabs/tabset.component.ts
@@ -7,7 +7,7 @@ import { TabDirective } from './tab.directive';
   selector: 'tabset',
   template: `
     <ul class="nav" [ngClass]="classMap" (click)="$event.preventDefault()">
-        <li *ngFor="let tabz of tabs" class="nav-item"
+        <li *ngFor="let tabz of orderedTabs" class="nav-item"
           [class.active]="tabz.active" [class.disabled]="tabz.disabled">
           <a href class="nav-link"
             [class.active]="tabz.active" [class.disabled]="tabz.disabled"
@@ -58,6 +58,10 @@ export class TabsetComponent implements OnInit, OnDestroy {
   }
 
   public tabs:Array<TabDirective> = [];
+
+  public get orderedTabs():Array<TabDirective> {
+     return this.tabs.sort((first:TabDirective, second:TabDirective) => first.index - second.index);
+  }
 
   private isDestroyed:boolean;
   private _vertical:boolean;

--- a/demo/components/tabs/tabs-demo.html
+++ b/demo/components/tabs/tabs-demo.html
@@ -20,7 +20,7 @@
          (removed)="removeTabHandler(tabz)">
       {{tabz?.content}}
     </tab>
-    <tab (select)="alertMe()">
+    <tab (select)="alertMe()" [index]="99">
       <template tabHeading>
         <i class="glyphicon glyphicon-bell"></i> Alert!
       </template>


### PR DESCRIPTION
Adding an index property to tab component allows a proper/custom ordering of the tabs.
Will fix #889 and #823.
