### PR TITLE
fix(positioning) don't modify readonly value

### DIFF
--- a/src/positioning/ng-positioning.ts
+++ b/src/positioning/ng-positioning.ts
@@ -12,7 +12,15 @@ export class Positioning {
     let parentOffset: ClientRect = {width: 0, height: 0, top: 0, bottom: 0, left: 0, right: 0};
 
     if (this.getStyle(element, 'position') === 'fixed') {
-      elPosition = element.getBoundingClientRect();
+      const bcRect = element.getBoundingClientRect();
+      elPosition = {
+        width: bcRect.width,
+        height: bcRect.height,
+        top: bcRect.top,
+        bottom: bcRect.bottom,
+        left: bcRect.left,
+        right: bcRect.right
+      };
     } else {
       const offsetParentEl = this.offsetParent(element);
 


### PR DESCRIPTION
(Positioning.position): element.getBoundingClientRect() returns a read-only value, so don't assign it directly to a variable whose properties are subsequently modified.