### PR TITLE
hotfix/modal-nested-close-on-esc solved

### DIFF
--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -254,6 +254,7 @@ export class ModalDirective implements AfterViewInit, OnDestroy {
         this.resetScrollbar();
       }
       this.resetAdjustments();
+      this.focusOtherModal();
       this.onHidden.emit(this);
     });
   }
@@ -334,6 +335,14 @@ export class ModalDirective implements AfterViewInit, OnDestroy {
   //   $(window).off(Event.RESIZE)
   // }
   // }
+
+  protected focusOtherModal() {
+    const otherOpenedModals = this._element.nativeElement.parentElement.querySelectorAll('.in[bsModal]');
+    if (!otherOpenedModals.length) {
+      return;
+    }
+    this._renderer.invokeElementMethod(otherOpenedModals[otherOpenedModals.length - 1], 'focus');
+  }
 
   /** @internal */
   protected resetAdjustments(): void {


### PR DESCRIPTION
issue: 
1. navigate to http://valor-software.com/ngx-bootstrap/#/modals#nested 
2. click "Open parent modal" - result: big modal opens - ok
3. click "Open second modal" - result: smaller modal opens - ok
4. keydown "ESC" button - result: smaller modal closes - ok 
5. keydown "ESC" button one more time - result: big modal don't closes - bug

Fixed by firing 'focus' event on next open modal if it is exist.

behavior after fix
1 - 4 same
5. keydown "ESC" button one more time - result: big modal closes - ok 