### PR TITLE
refactor(modal): generify BsModalRef to improve readabilty and type-checking

### DIFF
--- a/demo/src/app/components/+modal/demos/service-component/service-component.ts
+++ b/demo/src/app/components/+modal/demos/service-component/service-component.ts
@@ -7,7 +7,7 @@ import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
   templateUrl: './service-component.html'
 })
 export class DemoModalServiceFromComponent {
-  bsModalRef: BsModalRef;
+  bsModalRef: BsModalRef<ModalContentComponent>;
   constructor(private modalService: BsModalService) {}
 
   openModalWithComponent() {

--- a/demo/src/app/components/+modal/demos/service-confirm-window/service-confirm-window.ts
+++ b/demo/src/app/components/+modal/demos/service-confirm-window/service-confirm-window.ts
@@ -7,7 +7,7 @@ import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
   templateUrl: './service-confirm-window.html'
 })
 export class DemoModalServiceConfirmWindowComponent {
-  modalRef: BsModalRef;
+  modalRef: BsModalRef<null>;
   message: string;
   constructor(private modalService: BsModalService) {}
 

--- a/demo/src/app/components/+modal/demos/service-events/service-events.ts
+++ b/demo/src/app/components/+modal/demos/service-events/service-events.ts
@@ -13,7 +13,7 @@ import { combineLatest, Subscription } from 'rxjs';
   `]
 })
 export class DemoModalServiceEventsComponent {
-  modalRef: BsModalRef;
+  modalRef: BsModalRef<null>;
   subscriptions: Subscription[] = [];
   messages: string[] = [];
 

--- a/demo/src/app/components/+modal/demos/service-nested/service-nested.ts
+++ b/demo/src/app/components/+modal/demos/service-nested/service-nested.ts
@@ -7,8 +7,8 @@ import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
   templateUrl: './service-nested.html'
 })
 export class DemoModalServiceNestedComponent {
-  modalRef: BsModalRef;
-  modalRef2: BsModalRef;
+  modalRef: BsModalRef<null>;
+  modalRef2: BsModalRef<null>;
   constructor(private modalService: BsModalService) {}
 
   openModal(template: TemplateRef<any>) {

--- a/demo/src/app/components/+modal/demos/service-options/disable-backdrop/disable-backdrop.ts
+++ b/demo/src/app/components/+modal/demos/service-options/disable-backdrop/disable-backdrop.ts
@@ -7,7 +7,7 @@ import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
   templateUrl: './disable-backdrop.html'
 })
 export class DemoModalServiceDisableBackdropComponent {
-  modalRef: BsModalRef;
+  modalRef: BsModalRef<null>;
   config = {
     backdrop: true,
     ignoreBackdropClick: false

--- a/demo/src/app/components/+modal/demos/service-template/service-template.ts
+++ b/demo/src/app/components/+modal/demos/service-template/service-template.ts
@@ -7,7 +7,7 @@ import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
   templateUrl: './service-template.html'
 })
 export class DemoModalServiceStaticComponent {
-  modalRef: BsModalRef;
+  modalRef: BsModalRef<null>;
   constructor(private modalService: BsModalService) {}
 
   openModal(template: TemplateRef<any>) {

--- a/src/modal/bs-modal-ref.service.ts
+++ b/src/modal/bs-modal-ref.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
 
 @Injectable()
-export class BsModalRef {
+export class BsModalRef<T = any> {
   /**
    * Reference to a component inside the modal. Null if modal's been created with TemplateRef
    */
-  content?: any | null;
+  content?: T;
 
   /**
    * Hides the modal

--- a/src/modal/bs-modal.service.ts
+++ b/src/modal/bs-modal.service.ts
@@ -51,6 +51,9 @@ export class BsModalService {
   }
 
   /** Shows a modal */
+  show(content: string, config?: ModalOptions): BsModalRef;
+  show(content: TemplateRef<any>, config?: ModalOptions): BsModalRef<null>;
+  show<T>(content: {new (...args: any[]): T}, config?: ModalOptions): BsModalRef<T>;
   show(content: string | TemplateRef<any> | any, config?: ModalOptions): BsModalRef {
     this.modalsCount++;
     this._createLoaders();


### PR DESCRIPTION
Currently this example:
```typescript
class MyComponent {
  someProperty: string;
}
modalService.show(MyComponent).content.someProperty = 'demo';
```
Compiles, but type checking for `content` ist lost. This can be fixed using a cast:
```typescript
class MyComponent {
  someProperty: string;
}
(<MyComponent>modalService.show(MyComponent).content).someProperty = 'demo';
```

This PR generifies the `BsModalRef`, so that the cast is not needed anymore and thus improves readability.