### PR TITLE
docs(typehead): add demo for typeaheadOnSelect output #3681

### DIFF
--- a/demo/src/app/components/+typeahead/demos/basic/basic.html
+++ b/demo/src/app/components/+typeahead/demos/basic/basic.html
@@ -1,4 +1,4 @@
-<pre class="card card-block card-header">Model: {{selected | json}}</pre>
+<pre class="card card-block card-header mb-3">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"
        [typeahead]="states"
        class="form-control">

--- a/demo/src/app/components/+typeahead/demos/dropup/dropup.html
+++ b/demo/src/app/components/+typeahead/demos/dropup/dropup.html
@@ -1,4 +1,4 @@
-<pre class="card card-block card-header">Model: {{selected | json}}</pre>
+<pre class="card card-block card-header mb-3">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"
        [typeahead]="states"
        [dropup]="true"

--- a/demo/src/app/components/+typeahead/demos/field/field.html
+++ b/demo/src/app/components/+typeahead/demos/field/field.html
@@ -1,4 +1,4 @@
-<pre class="card card-block card-header">Model: {{customSelected | json}}</pre>
+<pre class="card card-block card-header mb-3">Model: {{customSelected | json}}</pre>
 <input [(ngModel)]="customSelected"
        [typeahead]="statesComplex"
        typeaheadOptionField="name"

--- a/demo/src/app/components/+typeahead/demos/grouping/grouping.html
+++ b/demo/src/app/components/+typeahead/demos/grouping/grouping.html
@@ -1,4 +1,4 @@
-<pre class="card card-block card-header">Model: {{groupSelected | json}}</pre>
+<pre class="card card-block card-header mb-3">Model: {{groupSelected | json}}</pre>
 <input [(ngModel)]="groupSelected"
        [typeahead]="statesComplex"
        typeaheadOptionField="name"

--- a/demo/src/app/components/+typeahead/demos/index.ts
+++ b/demo/src/app/components/+typeahead/demos/index.ts
@@ -13,6 +13,7 @@ import { DemoTypeaheadContainerComponent } from './container/container';
 import { DemoTypeaheadSingleWorldComponent } from './single-world/single-world';
 import { DemoTypeaheadPhraseDelimitersComponent } from './phrase-delimiters/phrase-delimiters';
 import { DemoTypeaheadFormComponent } from './form/form';
+import { DemoTypeaheadOnSelectComponent } from './on-select/on-select';
 
 export const DEMO_COMPONENTS = [
   DemoTypeaheadBasicComponent,
@@ -29,7 +30,8 @@ export const DEMO_COMPONENTS = [
   DemoTypeaheadOnBlurComponent,
   DemoTypeaheadLatinizeComponent
   DemoTypeaheadContainerComponent,
-  DemoTypeaheadFormComponent
+  DemoTypeaheadFormComponent,
+  DemoTypeaheadOnSelectComponent
 ];
 
 export const DEMOS = {
@@ -88,5 +90,9 @@ export const DEMOS = {
   scrollable: {
     component: require('!!raw-loader?lang=typescript!./scrollable/scrollable.ts'),
     html: require('!!raw-loader?lang=markup!./scrollable/scrollable.html')
+  },
+  onSelect: {
+    component: require('!!raw-loader?lang=typescript!./on-select/on-select.ts'),
+    html: require('!!raw-loader?lang=markup!./on-select/on-select.html')
   }
 };

--- a/demo/src/app/components/+typeahead/demos/item-template/item-template.html
+++ b/demo/src/app/components/+typeahead/demos/item-template/item-template.html
@@ -2,7 +2,7 @@
   <h5>This is: {{model | json}} Index: {{ index }}</h5>
 </ng-template>
 
-<pre class="card card-block card-header">Model: {{selected | json}}</pre>
+<pre class="card card-block card-header mb-3">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"
        [typeahead]="states"
        [typeaheadItemTemplate]="customItemTemplate"

--- a/demo/src/app/components/+typeahead/demos/on-select/on-select.html
+++ b/demo/src/app/components/+typeahead/demos/on-select/on-select.html
@@ -1,0 +1,8 @@
+<pre class="card card-block card-header mb-3">Model: {{selectedValue | json}}</pre>
+<pre class="card card-block card-header mb-3">Selected option: {{selectedOption | json}}</pre>
+
+<input [(ngModel)]="selectedValue"
+       [typeahead]="states"
+       typeaheadOptionField="name"
+       (typeaheadOnSelect)="onSelect($event)"
+       class="form-control">

--- a/demo/src/app/components/+typeahead/demos/on-select/on-select.ts
+++ b/demo/src/app/components/+typeahead/demos/on-select/on-select.ts
@@ -1,19 +1,14 @@
 import { Component } from '@angular/core';
-
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-import { TypeaheadMatch } from 'ngx-bootstrap/typeahead';
+import { TypeaheadMatch } from 'ngx-bootstrap/typeahead/typeahead-match.class';
 
 @Component({
-  selector: 'demo-typeahead-async',
-  templateUrl: './async.html'
+  selector: 'demo-typeahead-on-select',
+  templateUrl: './on-select.html'
 })
-export class DemoTypeaheadAsyncComponent {
-  asyncSelected: string;
-  typeaheadLoading: boolean;
-  typeaheadNoResults: boolean;
-  dataSource: Observable<any>;
-  statesComplex: any[] = [
+export class DemoTypeaheadOnSelectComponent {
+  selectedValue: string;
+  selectedOption: any;
+  states: any[] = [
     { id: 1, name: 'Alabama', region: 'South' },
     { id: 2, name: 'Alaska', region: 'West' },
     { id: 3, name: 'Arizona', region: 'West' },
@@ -66,28 +61,7 @@ export class DemoTypeaheadAsyncComponent {
     { id: 51, name: 'Wyoming', region: 'West' }
   ];
 
-  constructor() {
-    this.dataSource = Observable.create((observer: any) => {
-      // Runs on every search
-      observer.next(this.asyncSelected);
-    }).mergeMap((token: string) => this.getStatesAsObservable(token));
-  }
-
-  getStatesAsObservable(token: string): Observable<any> {
-    let query = new RegExp(token, 'ig');
-
-    return Observable.of(
-      this.statesComplex.filter((state: any) => {
-        return query.test(state.name);
-      })
-    );
-  }
-
-  changeTypeaheadLoading(e: boolean): void {
-    this.typeaheadLoading = e;
-  }
-
-  typeaheadOnSelect(e: TypeaheadMatch): void {
-    console.log('Selected value: ', e.value);
+  onSelect(event: TypeaheadMatch): void {
+    this.selectedOption = event.item;
   }
 }

--- a/demo/src/app/components/+typeahead/demos/scrollable/scrollable.html
+++ b/demo/src/app/components/+typeahead/demos/scrollable/scrollable.html
@@ -1,4 +1,4 @@
-<pre class="card card-block card-header">Model: {{selected | json}}</pre>
+<pre class="card card-block card-header mb-3">Model: {{selected | json}}</pre>
 <input [(ngModel)]="selected"
        [typeahead]="states"
        [typeaheadScrollable]="true"

--- a/demo/src/app/components/+typeahead/typeahead-section.list.ts
+++ b/demo/src/app/components/+typeahead/typeahead-section.list.ts
@@ -13,6 +13,7 @@ import { DemoTypeaheadFormComponent } from './demos/form/form';
 import { DemoTypeaheadContainerComponent } from './demos/container/container';
 import { DemoTypeaheadSingleWorldComponent } from './demos/single-world/single-world';
 import { DemoTypeaheadPhraseDelimitersComponent } from './demos/phrase-delimiters/phrase-delimiters';
+import { DemoTypeaheadOnSelectComponent } from './demos/on-select/on-select';
 
 import { ContentSection } from '../../docs/models/content-section.model';
 import { DemoTopSectionComponent } from '../../docs/demo-section-components/demo-top-section/index';
@@ -163,6 +164,16 @@ export const demoComponentContent: ContentSection[] = [
         component: require('!!raw-loader?lang=typescript!./demos/latinize/latinize.ts'),
         html: require('!!raw-loader?lang=markup!./demos/latinize/latinize.html'),
         outlet: DemoTypeaheadLatinizeComponent
+      },
+      {
+        title: 'On select',
+        anchor: 'on-select',
+        description: `
+          <p>Fired when an option was selected, returns an object with this option</p>
+        `,
+        component: require('!!raw-loader?lang=typescript!./demos/on-select/on-select.ts'),
+        html: require('!!raw-loader?lang=markup!./demos/on-select/on-select.html'),
+        outlet: DemoTypeaheadOnSelectComponent
       }
     ]
   },

--- a/src/typeahead/typeahead-container.component.ts
+++ b/src/typeahead/typeahead-container.component.ts
@@ -1,9 +1,18 @@
-import { Component, ElementRef, HostListener, QueryList, TemplateRef, ViewChild, ViewChildren, Renderer2 } from '@angular/core';
-import { isBs3 } from '../utils/theme-provider';
-import { TypeaheadMatch } from './typeahead-match.class';
+import {
+  Component,
+  ElementRef,
+  HostListener,
+  QueryList,
+  TemplateRef,
+  ViewChild,
+  ViewChildren,
+  Renderer2
+} from '@angular/core';
+
+import { isBs3, Utils } from '../utils';
 import { latinize } from './typeahead-utils';
+import { TypeaheadMatch } from './typeahead-match.class';
 import { TypeaheadDirective } from './typeahead.directive';
-import { Utils } from '../utils/utils.class';
 
 @Component({
   selector: 'typeahead-container',
@@ -195,7 +204,7 @@ export class TypeaheadContainerComponent {
       const ulPaddingTop = parseFloat((ulStyles['padding-top'] ? ulStyles['padding-top'] : '0').replace('px', ''));
       const optionHeight = parseFloat((liStyles['height'] ? liStyles['height'] : '0').replace('px', ''));
       const height = this.typeaheadOptionsInScrollableView * optionHeight;
-      this.guiHeight = (height + ulPaddingTop + ulPaddingBottom) + 'px';
+      this.guiHeight = `${height + ulPaddingTop + ulPaddingBottom}px`;
     }
     this.renderer.setStyle(this.element.nativeElement, 'visibility', 'visible');
   }
@@ -203,6 +212,7 @@ export class TypeaheadContainerComponent {
   scrollPrevious(index: number): void {
     if (index === 0) {
       this.scrollToBottom();
+
       return;
     }
     if (this.liElements) {
@@ -216,6 +226,7 @@ export class TypeaheadContainerComponent {
   scrollNext(index: number): void {
     if (index + 1 > this.matches.length - 1) {
       this.scrollToTop();
+
       return;
     }
     if (this.liElements) {
@@ -237,7 +248,7 @@ export class TypeaheadContainerComponent {
     const elemBottom = elemTop + elem.offsetHeight;
 
     return ((elemBottom <= containerViewBottom) && (elemTop >= containerViewTop));
-  }
+  };
 
   private scrollToBottom(): void {
     this.ulElement.nativeElement.scrollTop = this.ulElement.nativeElement.scrollHeight;


### PR DESCRIPTION
Add demo for typeaheadOnSelect output. To reproduce demo, please select one of the options and then you can see the selected option above the input ("Selected option"). [See screenshot ](http://joxi.ru/brRggRgHQZ9nam)

Close #3681

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [ ] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [ ] built and tested the changes locally.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
