### PR TITLE
fix(typeahead): incoming data are not filtered after typeahead kicks-in

### DIFF
--- a/demo/src/app/components/+typeahead/demos/async/async.html
+++ b/demo/src/app/components/+typeahead/demos/async/async.html
@@ -1,12 +1,8 @@
-<pre class="card card-block card-header">Model: {{asyncSelected | json}}</pre>
+<pre class="card card-block card-header">Model: {{ asyncSelected | json }}</pre>
 
 <input [(ngModel)]="asyncSelected"
-       [typeaheadAsync]="true"
        [typeahead]="dataSource"
-       (typeaheadLoading)="changeTypeaheadLoading($event)"
-       (typeaheadOnSelect)="typeaheadOnSelect($event)"
-       [typeaheadOptionsLimit]="7"
+       [typeaheadAsync]="true"
        typeaheadOptionField="name"
-       placeholder="Locations loaded with timeout"
+       placeholder="Locations loaded via observable"
        class="form-control">
-<div *ngIf="typeaheadLoading">Loading</div>

--- a/demo/src/app/components/+typeahead/demos/async/async.ts
+++ b/demo/src/app/components/+typeahead/demos/async/async.ts
@@ -1,8 +1,12 @@
 import { Component } from '@angular/core';
 
 import { Observable, of } from 'rxjs';
-import { TypeaheadMatch } from 'ngx-bootstrap/typeahead';
-import { mergeMap } from 'rxjs/operators';
+
+interface DataSourceType {
+  id: number;
+  name: string;
+  region: string;
+}
 
 @Component({
   selector: 'demo-typeahead-async',
@@ -10,10 +14,8 @@ import { mergeMap } from 'rxjs/operators';
 })
 export class DemoTypeaheadAsyncComponent {
   asyncSelected: string;
-  typeaheadLoading: boolean;
-  typeaheadNoResults: boolean;
-  dataSource: Observable<any>;
-  statesComplex: any[] = [
+  dataSource: Observable<DataSourceType[]>;
+  statesComplex: DataSourceType[] = [
     { id: 1, name: 'Alabama', region: 'South' },
     { id: 2, name: 'Alaska', region: 'West' },
     { id: 3, name: 'Arizona', region: 'West' },
@@ -67,30 +69,6 @@ export class DemoTypeaheadAsyncComponent {
   ];
 
   constructor() {
-    this.dataSource = Observable.create((observer: any) => {
-      // Runs on every search
-      observer.next(this.asyncSelected);
-    })
-      .pipe(
-        mergeMap((token: string) => this.getStatesAsObservable(token))
-      );
-  }
-
-  getStatesAsObservable(token: string): Observable<any> {
-    const query = new RegExp(token, 'i');
-
-    return of(
-      this.statesComplex.filter((state: any) => {
-        return query.test(state.name);
-      })
-    );
-  }
-
-  changeTypeaheadLoading(e: boolean): void {
-    this.typeaheadLoading = e;
-  }
-
-  typeaheadOnSelect(e: TypeaheadMatch): void {
-    console.log('Selected value: ', e.value);
+    this.dataSource = of(this.statesComplex);
   }
 }

--- a/src/spec/typeahead.directive.spec.ts
+++ b/src/spec/typeahead.directive.spec.ts
@@ -5,8 +5,9 @@ import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
-import { dispatchMouseEvent, dispatchTouchEvent, dispatchKeyboardEvent } from '@netbasal/spectator';
 import { of } from 'rxjs';
+import { dispatchMouseEvent, dispatchTouchEvent, dispatchKeyboardEvent } from '@netbasal/spectator';
+
 import { TypeaheadMatch, TypeaheadDirective, TypeaheadModule } from '../typeahead';
 
 interface State {
@@ -102,9 +103,8 @@ describe('Directive: Typeahead', () => {
       expect(directive.typeaheadSelectFirstItem).toBeTruthy();
     });
 
-    it('should typeaheadAsync to false, if typeahead is an observable', () => {
+    it('should typeaheadAsync to true, if typeahead is an observable', () => {
       directive.typeahead = of(component.states);
-
       directive.ngOnInit();
 
       expect(directive.typeaheadAsync).toBeTruthy();
@@ -342,6 +342,18 @@ describe('Directive: Typeahead', () => {
             'Alaska'
           )
         );
+      })
+    );
+
+    it('should result in 2 item matches, when "Ala" is entered in async mode', fakeAsync(() => {
+        directive.typeahead = of(component.states);
+        directive.ngOnInit();
+        inputElement.value = 'Ala';
+        dispatchTouchEvent(inputElement, 'input');
+        fixture.detectChanges();
+        tick(100);
+
+        expect(directive.matches.length).toBe(2);
       })
     );
 


### PR DESCRIPTION
Fix filtering incoming data after typeahead kicks-in. Remove filtering functionality from demo code to ngx-bootstrap component's code.

Close #3725

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated tests.
 - [x] added/updated API documentation.
 - [x] added/updated demos.
