### PR TITLE
docs(typehead): add demo for typeaheadPhraseDelimiters

### DIFF
--- a/demo/src/app/components/+typeahead/demos/index.ts
+++ b/demo/src/app/components/+typeahead/demos/index.ts
@@ -6,6 +6,7 @@ import { DemoTypeaheadFormsComponent } from './in-form/in-form';
 import { DemoTypeaheadGroupingComponent } from './grouping/grouping';
 import { DemoTypeaheadDropupComponent } from './dropup/dropup';
 import { DemoTypeaheadScrollableComponent } from './scrollable/scrollable';
+import { DemoTypeaheadPhraseDelimitersComponent } from './phrase-delimiters/phrase-delimiters';
 
 export const DEMO_COMPONENTS = [
   DemoTypeaheadStaticComponent,
@@ -14,6 +15,7 @@ export const DEMO_COMPONENTS = [
   DemoTypeaheadAsyncComponent,
   DemoTypeaheadFormsComponent,
   DemoTypeaheadGroupingComponent,
+  DemoTypeaheadPhraseDelimitersComponent,
   DemoTypeaheadDropupComponent,
   DemoTypeaheadScrollableComponent
 ];

--- a/demo/src/app/components/+typeahead/demos/phrase-delimiters/phrase-delimiters.html
+++ b/demo/src/app/components/+typeahead/demos/phrase-delimiters/phrase-delimiters.html
@@ -1,0 +1,6 @@
+<pre class="card card-block card-header">Model: {{selected | json}}</pre>
+<input [(ngModel)]="selected"
+       [typeahead]="states"
+       [typeaheadSingleWords]="true"
+       typeaheadPhraseDelimiters="&,"
+       class="form-control">

--- a/demo/src/app/components/+typeahead/demos/phrase-delimiters/phrase-delimiters.ts
+++ b/demo/src/app/components/+typeahead/demos/phrase-delimiters/phrase-delimiters.ts
@@ -1,0 +1,61 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'demo-typeahead-phrase-delimiters',
+  templateUrl: './phrase-delimiters.html'
+})
+export class DemoTypeaheadPhraseDelimitersComponent {
+  selected: string;
+  states = [
+    'Alabama',
+    'Alaska',
+    'Arizona',
+    'Arkansas',
+    'California',
+    'Colorado',
+    'Connecticut',
+    'Delaware',
+    'Florida',
+    'Georgia',
+    'Hawaii',
+    'Idaho',
+    'Illinois',
+    'Indiana',
+    'Iowa',
+    'Kansas',
+    'Kentucky',
+    'Louisiana',
+    'Maine',
+    'Maryland',
+    'Massachusetts',
+    'Michigan',
+    'Minnesota',
+    'Mississippi',
+    'Missouri',
+    'Montana',
+    'Nebraska',
+    'Nevada',
+    'New Hampshire',
+    'New Jersey',
+    'New Mexico',
+    'New York',
+    'North Dakota',
+    'North Carolina',
+    'Ohio',
+    'Oklahoma',
+    'Oregon',
+    'Pennsylvania',
+    'Rhode Island',
+    'South Carolina',
+    'South Dakota',
+    'Tennessee',
+    'Texas',
+    'Utah',
+    'Vermont',
+    'Virginia',
+    'Washington',
+    'West Virginia',
+    'Wisconsin',
+    'Wyoming'
+  ];
+}

--- a/demo/src/app/components/+typeahead/typeahead-section.list.ts
+++ b/demo/src/app/components/+typeahead/typeahead-section.list.ts
@@ -6,6 +6,7 @@ import { DemoTypeaheadFormsComponent } from './demos/in-form/in-form';
 import { DemoTypeaheadGroupingComponent } from './demos/grouping/grouping';
 import { DemoTypeaheadDropupComponent } from './demos/dropup/dropup';
 import { DemoTypeaheadScrollableComponent } from './demos/scrollable/scrollable';
+import { DemoTypeaheadPhraseDelimitersComponent } from './demos/phrase-delimiters/phrase-delimiters';
 
 import { ContentSection } from '../../docs/models/content-section.model';
 import { DemoTopSectionComponent } from '../../docs/demo-section-components/demo-top-section/index';
@@ -69,6 +70,14 @@ export const demoComponentContent: ContentSection[] = [
         component: require('!!raw-loader?lang=typescript!./demos/grouping/grouping.ts'),
         html: require('!!raw-loader?lang=markup!./demos/grouping/grouping.html'),
         outlet: DemoTypeaheadGroupingComponent
+      },
+      {
+        title: 'Phrase delimiters',
+        anchor: 'phrase-delimiters',
+        component: require('!!raw-loader?lang=typescript!./demos/phrase-delimiters/phrase-delimiters.ts'),
+        html: require('!!raw-loader?lang=markup!./demos/phrase-delimiters/phrase-delimiters.html'),
+        description: `Sets the word delimiter to match exact phrase. For example that are <code>&</code> and <code>,</code>`,
+        outlet: DemoTypeaheadPhraseDelimitersComponent
       },
       {
         title: 'Dropup',

--- a/demo/src/ng-api-doc.ts
+++ b/demo/src/ng-api-doc.ts
@@ -776,7 +776,7 @@ export const ngdoc: any = {
   "BsDatepickerConfig": {
     "fileName": "src/datepicker/bs-datepicker.config.ts",
     "className": "BsDatepickerConfig",
-    "description": "<p>For date range picker there are <code>BsDaterangepickerConfig</code> which inherits all properties,\nexcept displayMonths, for range picker it default to <code>2</code></p>\n",
+    "description": "<p>For date range picker there are <code>BsDaterangepickerConfig</code> which inherits all properties,\nexcept <code>displayMonths</code>, for range picker it default to <code>2</code></p>\n",
     "methods": [],
     "properties": [
       {


### PR DESCRIPTION
Sets the word delimiter to match exact phrase (you can divide keywords by typeaheadPhraseDelimiters)

Close #3847

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated demos.
