### PR TITLE
docs(timepicker): update titles and descriptions for demos

### DIFF
--- a/demo/src/app/components/+timepicker/demos/custom-validation/custom-validation.html
+++ b/demo/src/app/components/+timepicker/demos/custom-validation/custom-validation.html
@@ -6,7 +6,7 @@
 
 <pre class="alert"
      [class.alert-danger]="!ctrl.valid && !ctrl.pristine"
-     [class.alert-success]="ctrl.valid && !ctrl.pristine">
+     [class.alert-success]="(ctrl.valid && !ctrl.pristine) || ctrl.value == null">
   Time is: {{myTime}}
 </pre>
 <div class="alert alert-danger" *ngIf="ctrl.errors && ctrl.errors['outOfRange']">Invalid time</div>

--- a/demo/src/app/components/+timepicker/timepicker-section.list.ts
+++ b/demo/src/app/components/+timepicker/timepicker-section.list.ts
@@ -57,6 +57,7 @@ export const demoComponentContent: ContentSection[] = [
         anchor: 'custom-meridian',
         component: require('!!raw-loader?lang=typescript!./demos/custom-meridian/custom-meridian'),
         html: require('!!raw-loader?lang=markup!./demos/custom-meridian/custom-meridian.html'),
+        description: `<p>Text in meridian labels can be customized by using <code>meridians</code> input property</p>`,
         outlet: DemoTimepickerCustomMeridianComponent
       },
       {
@@ -102,13 +103,12 @@ export const demoComponentContent: ContentSection[] = [
         outlet: DemoTimepickerCustomValidationComponent
       },
       {
-        title: 'IsValid',
+        title: 'Custom validation with isValid event',
         anchor: 'isvalid',
         component: require('!!raw-loader?lang=typescript!./demos/isvalid/isvalid'),
         html: require('!!raw-loader?lang=markup!./demos/isvalid/isvalid.html'),
-        description: `
-        <p>isValid event emits true if a value is a valid date. Enter an invalid date to see the error</p>
-        `,
+        description: `<p><code>isValid</code> event emits true if a value is a valid data.
+            Enter an invalid data to see error</p>`,
         outlet: DemoTimepickerIsValidComponent
       },
       {


### PR DESCRIPTION
# PR Checklist
 - [x] built and tested the changes locally.
 - [x] updated demos.

Closes https://github.com/valor-software/ngx-bootstrap/issues/4140

Changes are highlighted on screenshots:
- `Custom meridian` demo: description was added:
![custommerupd](https://user-images.githubusercontent.com/27342505/38088842-f682d290-3365-11e8-9b01-dc1957c95576.jpg)
- `Custom validation`: was added one more condition for applying alert type:
![customvalidupd](https://user-images.githubusercontent.com/27342505/38088878-22b4cd6e-3366-11e8-80dc-5c2b9f43ea79.jpg)
- `IsValid` demo: title and description were updated:
![isvalidupd](https://user-images.githubusercontent.com/27342505/38088913-4729a174-3366-11e8-8835-fccd5b50b1ad.jpg)
