### PR TITLE
docs(tooltip): update demos description. Decompose Dynamic Content demo

### DIFF
--- a/demo/src/app/components/+tooltip/demos/custom-content/custom-content.html
+++ b/demo/src/app/components/+tooltip/demos/custom-content/custom-content.html
@@ -1,0 +1,4 @@
+<ng-template #tolTemplate>Just another: {{content}}</ng-template>
+<button type="button" class="btn btn-warning" [tooltip]="tolTemplate">
+  TemplateRef binding
+</button>

--- a/demo/src/app/components/+tooltip/demos/custom-content/custom-content.ts
+++ b/demo/src/app/components/+tooltip/demos/custom-content/custom-content.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'demo-tooltip-custom-content',
+  templateUrl: './custom-content.html'
+})
+export class DemoTooltipCustomContentComponent {
+  content = 'Vivamus sagittis lacus vel augue laoreet rutrum faucibus.';
+}

--- a/demo/src/app/components/+tooltip/demos/dynamic/dynamic.html
+++ b/demo/src/app/components/+tooltip/demos/dynamic/dynamic.html
@@ -1,16 +1,3 @@
-<div class="row">
-  <div class="mb-3 col-xs-12 col-12 col-lg-3">
-    <p>Pass a string as tooltip content</p>
-    <button type="button" class="btn btn-info" [tooltip]="content">
-      Simple binding
-    </button>
-  </div>
-  <div class="mb-3 col-xs-12 col-12 col-lg-9">
-    <p>or create <code>&lt;template #myId&gt;</code> with any html allowed by Angular, and provide template ref
-      <code>#myId</code> as tooltip content.</p>
-    <ng-template #tolTemplate>Just another: {{content}}</ng-template>
-    <button type="button" class="btn btn-warning" [tooltip]="tolTemplate">
-      TemplateRef binding
-    </button>
-  </div>
-</div>
+<button type="button" class="btn btn-info" [tooltip]="content">
+  Simple binding
+</button>

--- a/demo/src/app/components/+tooltip/demos/index.ts
+++ b/demo/src/app/components/+tooltip/demos/index.ts
@@ -11,11 +11,13 @@ import { DemoTooltipTriggersManualComponent } from './triggers-manual/triggers-m
 import { DemoTooltipDynamicHtmlComponent } from './dynamic-html/dynamic-html';
 import { DemoTooltipClassComponent } from './class/class';
 import { DemoTooltipDelayComponent } from './delay/delay';
+import { DemoTooltipCustomContentComponent } from './custom-content/custom-content';
 
 export const DEMO_COMPONENTS = [
   DemoTooltipBasicComponent,
   DemoTooltipPlacementComponent,
   DemoTooltipDismissComponent,
+  DemoTooltipCustomContentComponent,
   DemoTooltipDynamicComponent,
   DemoTooltipDynamicHtmlComponent,
   DemoTooltipContainerComponent,

--- a/demo/src/app/components/+tooltip/tooltip-section.list.ts
+++ b/demo/src/app/components/+tooltip/tooltip-section.list.ts
@@ -21,6 +21,7 @@ import {
   NgApiDocConfigComponent
 } from '../../docs/api-docs';
 import { DemoTooltipDelayComponent } from './demos/delay/delay';
+import { DemoTooltipCustomContentComponent } from './demos/custom-content/custom-content';
 
 export const demoComponentContent: ContentSection[] = [
   {
@@ -48,8 +49,9 @@ export const demoComponentContent: ContentSection[] = [
         anchor: 'placement',
         component: require('!!raw-loader?lang=typescript!./demos/placement/placement.ts'),
         html: require('!!raw-loader?lang=markup!./demos/placement/placement.html'),
-        description: `<p>Four positioning options are available: top, right, bottom, and left aligned.
-          Besides that, auto option may be used to detect a position that fits the component on the screen.</p>`,
+        description: `<p>Four positioning options are available: <code>top</code>, <code>right</code>,
+          <code>bottom</code>, and <code>left</code>. Besides that, <code>auto</code> option may be
+          used to detect a position that fits the component on the screen.</p>`,
         outlet: DemoTooltipPlacementComponent
       },
       {
@@ -66,15 +68,25 @@ export const demoComponentContent: ContentSection[] = [
         anchor: 'dynamic-content',
         component: require('!!raw-loader?lang=typescript!./demos/dynamic/dynamic.ts'),
         html: require('!!raw-loader?lang=markup!./demos/dynamic/dynamic.html'),
+        description: `<p>Pass a string as tooltip content</p>`,
         outlet: DemoTooltipDynamicComponent
+      },
+      {
+        title: 'Custom content template',
+        anchor: 'custom-content-template',
+        component: require('!!raw-loader?lang=typescript!./demos/custom-content/custom-content.ts'),
+        html: require('!!raw-loader?lang=markup!./demos/custom-content/custom-content.html'),
+        description: `<p>Create <code>&lt;ng-template #myId></code> with any html allowed by Angular,
+        and provide template ref <code>[tooltip]="myId"</code> as tooltip content</p>`,
+        outlet: DemoTooltipCustomContentComponent
       },
       {
         title: 'Dynamic Html',
         anchor: 'dynamic-html',
         component: require('!!raw-loader?lang=typescript!./demos/dynamic-html/dynamic-html.ts'),
         html: require('!!raw-loader?lang=markup!./demos/dynamic-html/dynamic-html.html'),
-        description: `<p>By using small trick you can display any dynamic html, which you got from ajax
-          request for example.</p>`,
+        description: `<p>By using <code>[innerHtml]</code> inside <code>ng-template</code> you
+          can display any dynamic html</p>`,
         outlet: DemoTooltipDynamicHtmlComponent
       },
       {
@@ -136,6 +148,7 @@ export const demoComponentContent: ContentSection[] = [
         anchor: 'tooltip-delay',
         component: require('!!raw-loader?lang=typescript!./demos/delay/delay.ts'),
         html: require('!!raw-loader?lang=markup!./demos/delay/delay.html'),
+        description: `<p>Hold on cursor above button for 0,5 second or more to see delayed tooltip</p>`,
         outlet: DemoTooltipDelayComponent
       }
     ]


### PR DESCRIPTION
# PR Checklist
 - [x] built and tested the changes locally.
 - [x] updated demos.

Closes https://github.com/valor-software/ngx-bootstrap/issues/4148
- `Placement` demo description was updated to following:
![placementtooltipupd](https://user-images.githubusercontent.com/27342505/38141004-0f85a9e6-343f-11e8-8138-94907b83c36a.jpg)
- `Dynamic Content` demo was decomposed. Also, demo description was updated and moved from html template to tooltip-section.list:
![dynamiccontentupd](https://user-images.githubusercontent.com/27342505/38141094-57541bc2-343f-11e8-81b4-8c73b8ede90d.jpg)
- `Dynamic Html` demo description was updated:
![dynamichtmlupd](https://user-images.githubusercontent.com/27342505/38141127-74761ad4-343f-11e8-91f8-81feca4a767f.jpg)
- `Tooltip with delay`: was added description to demo:
![tooltipwithdelupd](https://user-images.githubusercontent.com/27342505/38141158-8bacaa74-343f-11e8-8bbb-37e9ebfd5da5.jpg)
