### PR TITLE
Allow showing modals using components from lazy loaded module

### DIFF
--- a/demo/src/app/components/+modal/modal-section.list.ts
+++ b/demo/src/app/components/+modal/modal-section.list.ts
@@ -66,7 +66,9 @@ export const demoComponentContent: ContentSection[] = [
           in <code>.show()</code> method as in example, and don't forget to include your component to
           <code>entryComponents</code> of your <code>NgModule</code><br> If you passed a component
           to <code>.show()</code> you can get access to opened modal by injecting <code>BsModalRef</code>. Also you can pass data 
-          in your modal by adding <code>initialState</code> field in config. See example for more info</p>`,
+          in your modal by adding <code>initialState</code> field in config. If you are trying to use a component from a lazy
+          loaded module, be sure that your module provides a <code>ComponentLoaderFactory</code> and is added to the 
+          <code>ModalOptions</code> supplied to <code>.show()</code>. See example for more info</p>`,
         outlet: DemoModalServiceFromComponent
       },
       {

--- a/demo/src/ng-api-doc.ts
+++ b/demo/src/ng-api-doc.ts
@@ -1941,6 +1941,11 @@ export const ngdoc: any = {
         "name": "show",
         "type": "boolean",
         "description": "<p>Shows the modal when initialized.</p>\n"
+      },
+      {
+        "name": "componentLoaderFactory",
+        "type": "ComponentLoaderFactory",
+        "description": "<p> A custom component loader factory. Useful when trying to show a component from within a lazy loaded module.</p>\n"
       }
     ]
   },

--- a/src/modal/bs-modal.service.ts
+++ b/src/modal/bs-modal.service.ts
@@ -53,7 +53,11 @@ export class BsModalService {
   /** Shows a modal */
   show(content: string | TemplateRef<any> | any, config?: ModalOptions): BsModalRef {
     this.modalsCount++;
-    this._createLoaders();
+    if (config && config.componentLoaderFactory) {
+      this._createLoaders(config.componentLoaderFactory);
+    } else {
+      this._createLoaders(this.clf);
+    }
     this.config = Object.assign({}, modalConfigDefaults, config);
     this._showBackdrop();
     this.lastDismissReason = null;
@@ -180,8 +184,8 @@ export class BsModalService {
     return scrollbarWidth;
   }
 
-  private _createLoaders(): void {
-    const loader = this.clf.createLoader<ModalContainerComponent>(
+  private _createLoaders(clf: ComponentLoaderFactory): void {
+    const loader = clf.createLoader<ModalContainerComponent>(
       null,
       null,
       null

--- a/src/modal/modal-options.class.ts
+++ b/src/modal/modal-options.class.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { ComponentLoaderFactory } from '../component-loader/component-loader.factory';
 
 @Injectable()
 export class ModalOptions {
@@ -33,6 +34,11 @@ export class ModalOptions {
    * Modal data
    */
   initialState?: Object;
+  /**
+   * A custom component loader factory. Useful when trying to show a component
+   * from within a lazy loaded module.
+   */
+  componentLoaderFactory?: ComponentLoaderFactory
 }
 
 

--- a/src/modal/modal-options.class.ts
+++ b/src/modal/modal-options.class.ts
@@ -38,7 +38,7 @@ export class ModalOptions {
    * A custom component loader factory. Useful when trying to show a component
    * from within a lazy loaded module.
    */
-  componentLoaderFactory?: ComponentLoaderFactory
+  componentLoaderFactory?: ComponentLoaderFactory;
 }
 
 


### PR DESCRIPTION
A potential way to address #2356. The issue with using `.show()` and trying to show a component from a lazy loaded module is that the `ComponentLoaderFactory` created from `ModalModule.forRoot()` can only resolve components from the root injector and not from within the child injector. If the lazy loaded module provides its own `ComponentLoaderFactory`, it will receive a `ComponentFactoryResolver`/`Injector` that can properly resolve the lazy loaded module's entryComponents, providers, etc.

Another options would be to supply the `ComponentFactoryResolver` directly instead of the `ComponentLoaderFactory` but I think ultimately there is more flexibility in this approach.