### PR TITLE
fix(datepicker): Fix navigation alignment with preserveWhitespaces: false

### DIFF
--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -9,4 +9,4 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule, {preserveWhitespaces: true});
+platformBrowserDynamic().bootstrapModule(AppModule);

--- a/demo/src/tsconfig.json
+++ b/demo/src/tsconfig.json
@@ -24,8 +24,5 @@
   "exclude": [
     "src/test.ts",
     "**/*.spec.ts"
-  ],
-  "angularCompilerOptions": {
-    "preserveWhitespaces": true
-  }
+  ]
 }

--- a/src/datepicker/themes/bs/bs-datepicker-navigation-view.component.ts
+++ b/src/datepicker/themes/bs/bs-datepicker-navigation-view.component.ts
@@ -21,14 +21,23 @@ import {
             (click)="navTo(true)"><span>&lsaquo;</span>
     </button>
 
+    &#8203;  <!-- zero-width space needed for correct alignement
+                  with preserveWhitespaces: false in Angular -->
+
     <button class="current"
             *ngIf="calendar.monthTitle"
             (click)="view('month')"
     ><span>{{ calendar.monthTitle }}</span>
     </button>
 
+    &#8203;  <!-- zero-width space needed for correct alignement
+                  with preserveWhitespaces: false in Angular -->
+
     <button class="current" (click)="view('year')"
     ><span>{{ calendar.yearTitle }}</span></button>
+
+    &#8203;  <!-- zero-width space needed for correct alignement
+                  with preserveWhitespaces: false in Angular -->
 
     <button class="next"
             [disabled]="calendar.disableRightArrow"


### PR DESCRIPTION
When used with `preserveWhitespaces: false` compilation option in
Angular, the datepicker title elements are misaligned, because spaces
are missing in the justified text.

Since Angular 6, `preserveWhitespaces: false` is the default, so many
users will encounter this bug.

Let's add zero-width spaces in order to have a correct alignment in all
cases.

Closes #4443 