### PR TITLE
fix(demo): typeahead, wrong filtering

### DIFF
--- a/demo/src/app/components/+typeahead/demos/async/async.ts
+++ b/demo/src/app/components/+typeahead/demos/async/async.ts
@@ -77,7 +77,7 @@ export class DemoTypeaheadAsyncComponent {
   }
 
   getStatesAsObservable(token: string): Observable<any> {
-    const query = new RegExp(token, 'ig');
+    const query = new RegExp(token, 'i');
 
     return of(
       this.statesComplex.filter((state: any) => {


### PR DESCRIPTION
Fixes #4557
![123-1](https://user-images.githubusercontent.com/14885427/44397444-0af7ae80-a549-11e8-8db0-c91f6661bb3c.gif)

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [x] added/updated demos.
