### PR TITLE
fix(export): export datepicker container and associated services

### DIFF
--- a/src/datepicker/index.ts
+++ b/src/datepicker/index.ts
@@ -12,3 +12,7 @@ export { BsDaterangepickerDirective } from './bs-daterangepicker.component';
 export { BsDatepickerConfig } from './bs-datepicker.config';
 export { BsDaterangepickerConfig } from './bs-daterangepicker.config';
 export { BsLocaleService } from './bs-locale.service';
+
+export { BsDatepickerEffects } from './reducer/bs-datepicker.effects';
+export { BsDatepickerStore } from './reducer/bs-datepicker.store';
+export { BsDatepickerContainerComponent } from './themes/bs/bs-datepicker-container.component';

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,11 @@ export {
   BsDaterangepickerConfig,
   BsLocaleService,
   BsDaterangepickerDirective,
-  BsDatepickerDirective
+  BsDatepickerDirective,
+
+  BsDatepickerEffects,
+  BsDatepickerStore,
+  BsDatepickerContainerComponent,
 } from './datepicker/index';
 
 export {


### PR DESCRIPTION
For some projects I need to use an inline datepicker with new styles (it is also requested by others here #3955 ). It might not be on the project timeline, I can understand that. BTW I made the minimum changes for us to be able to build it by exporting BsDatepickerContainerComponent and associated services.
I pullrequest it on master branch because for my projects we are still on 2.x versions. I can backport it if you want on development branch.

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [X] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
