### PR TITLE
fix(datepicker): change default trigger from click to focus in DatePicker and DateRangePicker

### DIFF
--- a/cypress/integration/demo_pages_spec.ts
+++ b/cypress/integration/demo_pages_spec.ts
@@ -665,11 +665,11 @@ describe('Datepicker demo page test suite', () => {
     const basic = datepicker.exampleDemosArr.basic;
 
     it('basic date- and daterangepicker can be opened by click on input', () => {
-      cy.get(`${ basic } ${ datepicker.datepickerInput }`).click();
+      cy.get(`${ basic } ${ datepicker.datepickerInput }`).focus();
       cy.get(datepicker.datepickerLastOpened)
         .should('to.be.visible');
 
-      cy.get(`${ basic } ${ datepicker.daterangepickerInput }`).click();
+      cy.get(`${ basic } ${ datepicker.daterangepickerInput }`).focus();
       cy.get(datepicker.daterangepickerLastOpened)
         .should('to.be.visible');
     });
@@ -700,7 +700,7 @@ describe('Datepicker demo page test suite', () => {
       const expectedDate = Cypress.moment().format('YYYY-MM-DD');
       const day = Cypress.moment().format('D');
 
-      cy.get(`${ reactiveForms } ${ datepicker.datepickerInput }`).click();
+      cy.get(`${ reactiveForms } ${ datepicker.datepickerInput }`).focus();
       datepicker.clickOnDayInCurrMonth(`${ datepicker.datepickerLastOpened }`, day);
 
       cy.get(`${ reactiveForms } ${ datepicker.formOutput }`)

--- a/demo/src/app/components/+datepicker/demos/outside-click/outside-click.html
+++ b/demo/src/app/components/+datepicker/demos/outside-click/outside-click.html
@@ -1,10 +1,10 @@
 <div class="row">
   <div class="col-xs-12 col-12 col-sm-6 col-md-5 form-group">
     <p>Outside click closes the datepicker in this example</p>
-    <input class="form-control" placeholder="Datepicker" bsDatepicker [outsideClick]="true">
+    <input class="form-control" placeholder="Datepicker" bsDatepicker triggers="click" [outsideClick]="true">
   </div>
   <div class="col-xs-12 col-12 col-sm-6 col-md-5 form-group">
     <p>Outside click doesn't close the datepicker in this example</p>
-    <input class="form-control" placeholder="Datepicker" bsDatepicker [outsideClick]="false">
+    <input class="form-control" placeholder="Datepicker" bsDatepicker triggers="click" [outsideClick]="false">
   </div>
 </div>

--- a/demo/src/ng-api-doc.ts
+++ b/demo/src/ng-api-doc.ts
@@ -726,7 +726,7 @@ export const ngdoc: any = {
       },
       {
         "name": "triggers",
-        "defaultValue": "click",
+        "defaultValue": "focusin",
         "type": "string",
         "description": "<p>Specifies events that should trigger. Supports a space separated list of\nevent names.</p>\n"
       }
@@ -876,7 +876,7 @@ export const ngdoc: any = {
       },
       {
         "name": "triggers",
-        "defaultValue": "click",
+        "defaultValue": "focusin",
         "type": "string",
         "description": "<p>Specifies events that should trigger. Supports a space separated list of\nevent names.</p>\n"
       }

--- a/src/datepicker/bs-datepicker.component.ts
+++ b/src/datepicker/bs-datepicker.component.ts
@@ -21,7 +21,7 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges {
    * Specifies events that should trigger. Supports a space separated list of
    * event names.
    */
-  @Input() triggers = 'click';
+  @Input() triggers = 'focusin';
   /**
    * Close datepicker on outside click
    */

--- a/src/datepicker/bs-daterangepicker.component.ts
+++ b/src/datepicker/bs-daterangepicker.component.ts
@@ -34,7 +34,7 @@ export class BsDaterangepickerDirective
    * Specifies events that should trigger. Supports a space separated list of
    * event names.
    */
-  @Input() triggers = 'click';
+  @Input() triggers = 'focusin';
   /**
    * Close daterangepicker on outside click
    */


### PR DESCRIPTION
**DO NOT MERGE:** _datepicker don't hide after focusout by tabbing_

Close: #3194

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated tests.
 - [x] added/updated API documentation.
 - [x] added/updated demos.
