### PR TITLE
feat(typeahead): Provide event which caused the selection

### DIFF
--- a/src/typeahead/typeahead-container.component.ts
+++ b/src/typeahead/typeahead-container.component.ts
@@ -100,8 +100,8 @@ export class TypeaheadContainerComponent {
     return this.parent ? this.parent.typeaheadItemTemplate : undefined;
   }
 
-  selectActiveMatch(): void {
-    this.selectMatch(this._active);
+  selectActiveMatch(e: any): void {
+    this.selectMatch(this._active, e);
   }
 
   prevActiveMatch(): void {
@@ -188,6 +188,9 @@ export class TypeaheadContainerComponent {
       e.preventDefault();
     }
     this.parent.changeModel(value);
+
+    value.selectEvent = e;
+
     setTimeout(() => this.parent.typeaheadOnSelect.emit(value), 0);
 
     return false;

--- a/src/typeahead/typeahead-match.class.ts
+++ b/src/typeahead/typeahead-match.class.ts
@@ -1,4 +1,5 @@
 export class TypeaheadMatch {
+  selectEvent: Event = null;
   readonly value: string;
   readonly item: any;
   protected header: boolean;

--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -214,7 +214,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
 
       // enter, tab
       if (e.keyCode === 13) {
-        this._container.selectActiveMatch();
+        this._container.selectActiveMatch(e);
 
         return;
       }
@@ -254,7 +254,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
     // if an item is visible - don't change focus
     if (e.keyCode === 9) {
       e.preventDefault();
-      this._container.selectActiveMatch();
+      this._container.selectActiveMatch(e);
 
       return;
     }


### PR DESCRIPTION
I propose the solution for https://github.com/valor-software/ngx-bootstrap/issues/4685 – I suggest providing event(MouseEvent or KeyboardEvent) with emitted TypeaheadMatch