### PR TITLE
fix: XSS issue in typeahead component

### DIFF
--- a/src/spec/typeahead-container.component.spec.ts
+++ b/src/spec/typeahead-container.component.spec.ts
@@ -63,8 +63,8 @@ describe('Component: TypeaheadContainer', () => {
     beforeEach(() => {
       component.query = 'fo';
       component.matches = [
-        new TypeaheadMatch({ id: 0, name: 'foo' }, 'foo'),
-        new TypeaheadMatch({ id: 1, name: 'food' }, 'food')
+        new TypeaheadMatch({ id: 0, name: '&foo' }, '&foo'),
+        new TypeaheadMatch({ id: 1, name: '<food>' }, '<food>')
       ];
       fixture.detectChanges();
 
@@ -76,6 +76,13 @@ describe('Component: TypeaheadContainer', () => {
     describe('rendering', () => {
       it('should render 2 matches', () => {
         expect(matches.length).toBe(2);
+      });
+
+      it('escapes the markup to prevent XSS', () => {
+        const ms = fixture.debugElement.queryAll(
+          By.css('.dropdown-menu li span')
+        );
+        expect(ms[1].nativeElement.innerHTML).toBe('&lt;<strong>fo</strong>od&gt;');
       });
 
       xit('should highlight query for match', () => {

--- a/src/typeahead/typeahead-container.component.ts
+++ b/src/typeahead/typeahead-container.component.ts
@@ -135,6 +135,13 @@ export class TypeaheadContainerComponent {
     this._active = value;
   }
 
+  toSafeHTML(input: string): string {
+    const doc = new DOMParser().parseFromString('', 'text/html');
+    doc.body.appendChild(doc.createTextNode(input));
+
+    return doc.body.innerHTML;
+  }
+
   highlight(match: TypeaheadMatch, query: string[] | string): string {
     let itemStr: string = match.value;
     let itemStrHelper: string = (this.parent && this.parent.typeaheadLatinize
@@ -151,11 +158,12 @@ export class TypeaheadContainerComponent {
         tokenLen = query[i].length;
         if (startIdx >= 0 && tokenLen > 0) {
           itemStr =
-            `${itemStr.substring(0, startIdx)}<strong>${itemStr.substring(startIdx, startIdx + tokenLen)}</strong>` +
-            `${itemStr.substring(startIdx + tokenLen)}`;
+            `${this.toSafeHTML(itemStr.substring(0, startIdx))}` +
+            `<strong>${this.toSafeHTML(itemStr.substring(startIdx, startIdx + tokenLen))}</strong>` +
+            `${this.toSafeHTML(itemStr.substring(startIdx + tokenLen))}`;
           itemStrHelper =
-            `${itemStrHelper.substring(0, startIdx)}        ${' '.repeat(tokenLen)}         ` +
-            `${itemStrHelper.substring(startIdx + tokenLen)}`;
+            `${this.toSafeHTML(itemStrHelper.substring(0, startIdx))}        ${' '.repeat(tokenLen)}         ` +
+            `${this.toSafeHTML(itemStrHelper.substring(startIdx + tokenLen))}`;
         }
       }
     } else if (query) {
@@ -164,8 +172,9 @@ export class TypeaheadContainerComponent {
       tokenLen = query.length;
       if (startIdx >= 0 && tokenLen > 0) {
         itemStr =
-          `${itemStr.substring(0, startIdx)}<strong>${itemStr.substring(startIdx, startIdx + tokenLen)}</strong>` +
-          `${itemStr.substring(startIdx + tokenLen)}`;
+          `${this.toSafeHTML(itemStr.substring(0, startIdx))}` +
+          `<strong>${this.toSafeHTML(itemStr.substring(startIdx, startIdx + tokenLen))}</strong>` +
+          `${this.toSafeHTML(itemStr.substring(startIdx + tokenLen))}`;
       }
     }
 


### PR DESCRIPTION
Even though it is possible to expect that the provided options are safe,
such assumption will cause weird highlighting behavior. For example, if
`<foo>` is provided as option, the safe version would be `&lt;foo&gt;`.
This means that user will see the `<` & `>` characters but if they
search for it, nothing would match.

Hence, this is a better to escape the string in typeahead component so
the search and highlight functionality will remain properly functional.

An example of XSS attack when using typeahead:

![image-2018-11-06-13-45-15-795](https://user-images.githubusercontent.com/194719/48845074-e1466180-ed9b-11e8-80db-35460ad3ac39.png)

how this will look like after this patch:

![deepinscreenshot_select-area_20181121171427](https://user-images.githubusercontent.com/194719/48853972-faa5d880-edb0-11e8-8daf-814db86b46cd.png)

