### PR TITLE
fix(datepicker-input): restrict datepicker input to valid dates

### DIFF
--- a/src/datepicker/bs-datepicker-input.directive.ts
+++ b/src/datepicker/bs-datepicker-input.directive.ts
@@ -84,7 +84,9 @@ export class BsDatepickerInputDirective
   }
 
   _setInputValue(value: Date): void {
-    const initialDate = !value ? ''
+    const initialDate = !value || isBefore(value, this._picker.minDate, 'date')
+      || isAfter(value, this._picker.maxDate, 'date') || !isDateValid(value)
+      ? ''
       : formatDate(value, this._picker._config.dateInputFormat, this._localeService.currentLocale);
 
     this._renderer.setProperty(this._elRef.nativeElement, 'value', initialDate);


### PR DESCRIPTION
Currently there are not restrictions on the text input for the datepicker.

This restricts the text input to valid dates, and if there is `minDate` and/or `maxDate` supplied then it will not allow the user to input dates outside of that range.


# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [X] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
