### PR TITLE
feat(tooltip): add delay to config

### DIFF
--- a/demo/src/app/components/+tooltip/demos/config/config.ts
+++ b/demo/src/app/components/+tooltip/demos/config/config.ts
@@ -6,7 +6,8 @@ import { TooltipConfig } from 'ngx-bootstrap/tooltip';
 export function getAlertConfig(): TooltipConfig {
   return Object.assign(new TooltipConfig(), {
     placement: 'right',
-    container: 'body'
+    container: 'body',
+    delay: 500
   });
 }
 

--- a/docs/spec/tooltip/tooltip.examples.config-defaults.use-case.md
+++ b/docs/spec/tooltip/tooltip.examples.config-defaults.use-case.md
@@ -11,7 +11,7 @@ Main success scenario:
 1. User opens Tooltip demo page
 2. User clicks on Configuring defaults sub-menu
 3. User see button "Preconfigured tooltip"
-4. When user hover on "Preconfigured tooltip", then tooltip-container shown on the right of button with specific text
+4. When user hover on "Preconfigured tooltip", then tooltip-container shown on the right of button with specific text after 500ms
 5. When user moves the mouse cursor away of tooltip-button, then tooltip-container disappeared
 6. Component src should be written with TooltipConfig and parameter: placement: "right"
 

--- a/src/spec/ng-bootstrap/tooltip.spec.ts
+++ b/src/spec/ng-bootstrap/tooltip.spec.ts
@@ -523,6 +523,7 @@ describe('tooltip', () => {
         config.placement = 'bottom';
         config.triggers = 'click';
         config.container = 'body';
+        config.delay = 500;
       })
     );
 
@@ -534,6 +535,7 @@ describe('tooltip', () => {
       expect(tooltip.placement).toBe(config.placement);
       expect(tooltip.triggers).toBe(config.triggers);
       expect(tooltip.container).toBe(config.container);
+      expect(tooltip.delay).toBe(config.delay);
     });
   });
 
@@ -542,6 +544,7 @@ describe('tooltip', () => {
     config.placement = 'bottom';
     config.triggers = 'click';
     config.container = 'body';
+    config.delay = 500;
 
     beforeEach(() => {
       TestBed.configureTestingModule({
@@ -557,6 +560,7 @@ describe('tooltip', () => {
       expect(tooltip.placement).toBe(config.placement);
       expect(tooltip.triggers).toBe(config.triggers);
       expect(tooltip.container).toBe(config.container);
+      expect(tooltip.delay).toBe(config.delay);
     });
   });
 });

--- a/src/tooltip/tooltip.config.ts
+++ b/src/tooltip/tooltip.config.ts
@@ -9,4 +9,6 @@ export class TooltipConfig {
   triggers = 'hover focus';
   /** a selector specifying the element the tooltip should be appended to. Currently only supports "body" */
   container: string;
+  /** delay before showing the tooltip */
+  delay = 0;
 }


### PR DESCRIPTION
The default delay of tooltips can be configured.

closes #4702

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated tests.
 - [x] added/updated API documentation.
 - [x] added/updated demos.
