### PR TITLE
Reset view state day to 1 when month or year is selected

### DIFF
--- a/src/datepicker/bs-datepicker.spec.ts
+++ b/src/datepicker/bs-datepicker.spec.ts
@@ -49,8 +49,8 @@ describe('datepicker:', () => {
   let fixture: TestFixture;
   beforeEach(
     async(() => TestBed.configureTestingModule({
-        declarations: [TestComponent],
-        imports: [BsDatepickerModule.forRoot()]
+      declarations: [TestComponent],
+      imports: [BsDatepickerModule.forRoot()]
     }).compileComponents()
     ));
   beforeEach(() => {
@@ -79,7 +79,7 @@ describe('datepicker:', () => {
     datepickerContainerInstance[`_store`]
       .select(state => state.view)
       .subscribe(view => {
-          expect(view.date.getFullYear()).toEqual(monthSelection.date.getFullYear());
+        expect(view.date.getFullYear()).toEqual(monthSelection.date.getFullYear());
       });
   });
 
@@ -102,4 +102,19 @@ describe('datepicker:', () => {
 
     expect(spy).toHaveBeenCalled();
   }));
+
+  it('should display day selection for the correct month when month is selected from month-selection view', () => {
+    const datepicker = showDatepicker(fixture);
+    const datepickerContainerInstance = getDatepickerContainer(datepicker);
+    const daySelection: CalendarCellViewModel = { date: new Date(2018, 9, 31), label: 'label' };
+    const monthSelection: CalendarCellViewModel = { date: new Date(2018, 10, 1), label: 'label' };
+    datepickerContainerInstance.daySelectHandler(daySelection);
+    datepickerContainerInstance.monthSelectHandler(monthSelection);
+    fixture.detectChanges();
+    datepickerContainerInstance[`_store`]
+      .select(state => state.view)
+      .subscribe(view => {
+        expect(view.date.getMonth()).toEqual(monthSelection.date.getMonth());
+      });
+  });
 });

--- a/src/datepicker/reducer/bs-datepicker.effects.ts
+++ b/src/datepicker/reducer/bs-datepicker.effects.ts
@@ -154,6 +154,7 @@ export class BsDatepickerEffects {
       this._store.dispatch(
         this._actions.navigateTo({
           unit: {
+            day: 1,
             month: getMonth(event.date),
             year: getFullYear(event.date)
           },
@@ -169,6 +170,8 @@ export class BsDatepickerEffects {
       this._store.dispatch(
         this._actions.navigateTo({
           unit: {
+            day: 1,
+            month: 0,
             year: getFullYear(event.date)
           },
           viewMode: 'month'


### PR DESCRIPTION
When a month is selected, the 'day' field was not updated. This caused erroneous behavior in certain cases. For eg. if the current selected date is Oct 31, 2018 and user goes to the month selection view and chooses November, system tries to set the view state date to Nov 31, 2018. Since Nov has only 30 days, the current date is pushed to 1 Dec 2018. In effect, when Nov is chosen, the calendar for Dec was displayed.

When a month is selected, the view state day is now explicitly set to 1. Similarly, when an year is selected, month is set to 0 and day is set to 1.

Fixes #4396 

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
