### PR TITLE
fix(datepicker): change isOpen setter flow (#5035)

### DIFF
--- a/src/datepicker/bs-datepicker.component.ts
+++ b/src/datepicker/bs-datepicker.component.ts
@@ -1,10 +1,11 @@
 import {
   ComponentRef, Directive, ElementRef, EventEmitter, Input, OnChanges,
-  OnDestroy, OnInit, Output, Renderer2, SimpleChanges, ViewContainerRef
+  OnDestroy, OnInit, Output, Renderer2, SimpleChanges, ViewContainerRef, AfterViewInit
 } from '@angular/core';
 import { ComponentLoader, ComponentLoaderFactory } from 'ngx-bootstrap/component-loader';
 import { BsDatepickerContainerComponent } from './themes/bs/bs-datepicker-container.component';
-import { Subscription } from 'rxjs';
+import { Subscription, Subject, BehaviorSubject } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 import { BsDatepickerConfig } from './bs-datepicker.config';
 import { BsDatepickerViewMode, DatepickerDateCustomClasses } from './models';
 
@@ -12,7 +13,7 @@ import { BsDatepickerViewMode, DatepickerDateCustomClasses } from './models';
   selector: '[bsDatepicker]',
   exportAs: 'bsDatepicker'
 })
-export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges {
+export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges, AfterViewInit {
   /**
    * Placement of a datepicker. Accepts: "top", "bottom", "left", "right"
    */
@@ -42,11 +43,7 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges {
   }
 
   set isOpen(value: boolean) {
-    if (value) {
-      this.show();
-    } else {
-      this.hide();
-    }
+    this.isOpen$.next(value);
   }
 
   /**
@@ -61,6 +58,8 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges {
   @Output() onHidden: EventEmitter<any>;
 
   _bsValue: Date;
+  isOpen$: BehaviorSubject<boolean>;
+  isDestroy$: Subject<void>;
   /**
    * Initial value of datepicker
    */
@@ -136,9 +135,11 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges {
     );
     this.onShown = this._datepicker.onShown;
     this.onHidden = this._datepicker.onHidden;
+    this.isOpen$ = new BehaviorSubject(this.isOpen);
   }
 
   ngOnInit(): void {
+    this.isDestroy$ = new Subject();
     this._datepicker.listen({
       outsideClick: this.outsideClick,
       outsideEsc: this.outsideEsc,
@@ -180,6 +181,14 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges {
     if (changes.dateCustomClasses) {
       this._datepickerRef.instance.dateCustomClasses = this.dateCustomClasses;
     }
+  }
+
+  ngAfterViewInit(): void {
+    this.isOpen$.pipe(
+      filter(isOpen => isOpen !== this.isOpen),
+      takeUntil(this.isDestroy$)
+    )
+    .subscribe(() => this.toggle());
   }
 
   /**
@@ -264,5 +273,10 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges {
 
   ngOnDestroy(): void {
     this._datepicker.dispose();
+    this.isOpen$.next(false);
+    if (this.isDestroy$) {
+      this.isDestroy$.next();
+      this.isDestroy$.complete();
+    }
   }
 }


### PR DESCRIPTION
Watch after isOpen input changes only after component's view initiated

closes #5035

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
