### PR TITLE
Fix bug - when position is not set to auto, dont flip the position su…

### DIFF
--- a/src/positioning/ng-positioning.ts
+++ b/src/positioning/ng-positioning.ts
@@ -26,7 +26,7 @@ export class Positioning {
     appendToBody?: boolean,
     options?: Options
   ): Data {
-    const chainOfModifiers = [flip, shift, preventOverflow, arrow];
+    const chainOfModifiers = position === 'auto' ? [flip, shift, preventOverflow, arrow] : [shift, preventOverflow, arrow];
 
     return chainOfModifiers.reduce(
       (modifiedData, modifier) => modifier(modifiedData),


### PR DESCRIPTION
…ch as in popover where we always want configured position

version of Angular used - Angular 6/7
version on ngx-bootstrap used - 4.0.1
build system: Webpack
and most importantly - popover position flips to top and bottom even when placement="bottom". Expecting flip to happen with "auto". This is obvious when popover is initiated from a list row in a container with scroll and there is no room left below in the grid container.

 - [YES ] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [YES ] built and tested the changes locally.
 - [NO ] added/updated tests.
 - [NO] added/updated API documentation.
 - [NO - Doesnt affect demo ] added/updated demos. 
