### PR TITLE
Fix link to Cypress.io favicon in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Crossbrowser testing sponsored by [Saucelabs](https://saucelabs.com/)
 [<img src="https://saucelabs.com/content/images/circle-logo@2x.png" alt="Saucelabs" width="31" height="31">](https://saucelabs.com/)
 
 End-to-end testing sponsored by [Cypress](https://www.cypress.io/)
-[<img src="https://www.cypress.io/img/favicon.ico" alt="Cypress" width="31" height="31">](https://www.cypress.io/)
+[<img src="https://raw.githubusercontent.com/cypress-io/cypress-icons/master/src/favicon/favicon.ico" alt="Cypress" width="31" height="31">](https://www.cypress.io/)
 
 ### License
 


### PR DESCRIPTION
Just a little change to the README. thanks! 😄 	