### PR TITLE
feat(typeahead): allow optionsListTemplate to access typeahead-container's functions and Demo

### DIFF
--- a/demo/src/app/components/+typeahead/demos/index.ts
+++ b/demo/src/app/components/+typeahead/demos/index.ts
@@ -16,6 +16,7 @@ import { DemoTypeaheadMinLengthComponent } from './min-length/min-length';
 import { DemoTypeaheadNoResultComponent } from './no-result/no-result';
 import { DemoTypeaheadOnBlurComponent } from './on-blur/on-blur';
 import { DemoTypeaheadOnSelectComponent } from './on-select/on-select';
+import { DemoTypeaheadOptionsListTemplateComponent } from './options-list-template/options-list-template';
 import { DemoTypeaheadPhraseDelimitersComponent } from './phrase-delimiters/phrase-delimiters';
 import { DemoTypeaheadReactiveFormComponent } from './reactive-form/reactive-form';
 import { DemoTypeaheadScrollableComponent } from './scrollable/scrollable';
@@ -42,6 +43,7 @@ export const DEMO_COMPONENTS = [
   DemoTypeaheadNoResultComponent,
   DemoTypeaheadOnBlurComponent,
   DemoTypeaheadOnSelectComponent,
+  DemoTypeaheadOptionsListTemplateComponent,
   DemoTypeaheadPhraseDelimitersComponent,
   DemoTypeaheadReactiveFormComponent,
   DemoTypeaheadScrollableComponent,

--- a/demo/src/app/components/+typeahead/demos/options-list-template/options-list-template.html
+++ b/demo/src/app/components/+typeahead/demos/options-list-template/options-list-template.html
@@ -1,0 +1,49 @@
+<!-- Bootstrap 3 options list template -->
+<ng-template #bs3Template let-context let-itemTemplate="itemTemplate">
+  <ul class="dropdown-menu"
+      #ulElement
+      [style.overflow-y]="context.needScrollbar ? 'scroll': 'auto'"
+      [style.height]="context.needScrollbar ? guiHeight: 'auto'">
+    <ng-template ngFor let-match let-i="index" [ngForOf]="context.matches">
+      <li #liElements *ngIf="match.isHeader()" class="dropdown-header">{{ match }}</li>
+      <li #liElements
+          *ngIf="!match.isHeader()"
+          [class.active]="context.isActive(match)"
+          (mouseenter)="context.selectActive(match)">
+
+        <a href="#" (click)="context.selectMatch(match, $event)" tabindex="-1">
+          <ng-template [ngTemplateOutlet]="itemTemplate"
+                       [ngTemplateOutletContext]="{item:match.item, index:i, match:match, query:context.query}"></ng-template>
+        </a>
+      </li>
+    </ng-template>
+
+    <li class="dropdown-header">
+      <small><b>Powered by searchengine</b></small>
+    </li>
+  </ul>
+</ng-template>
+
+<!-- Bootstrap 4 options list template -->
+<ng-template #bs4Template let-matches="matches" let-context let-itemTemplate="itemTemplate">
+  <ng-template ngFor let-match let-i="index" [ngForOf]="matches">
+    <button #liElements
+            class="dropdown-item"
+            (click)="context.selectMatch(match, $event)"
+            (mouseenter)="context.selectActive(match)"
+            [class.active]="context.isActive(match)">
+      <ng-template [ngTemplateOutlet]="itemTemplate"
+                   [ngTemplateOutletContext]="{item:match.item, index:i, match:match, query:context.query}"></ng-template>
+    </button>
+  </ng-template>
+
+  <small class="d-block text-right px-3 pt-1">
+    <b>Powered by searchengine</b>
+  </small>
+</ng-template>
+
+<pre class="card card-block card-header mb-3">Model: {{selected | json}}</pre>
+<input [(ngModel)]="selected"
+       [typeahead]="states"
+       [optionsListTemplate]="isBs3 ? bs3Template : bs4Template"
+       class="form-control">

--- a/demo/src/app/components/+typeahead/demos/options-list-template/options-list-template.ts
+++ b/demo/src/app/components/+typeahead/demos/options-list-template/options-list-template.ts
@@ -1,0 +1,64 @@
+import { isBs3 } from 'ngx-bootstrap/utils';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'demo-typeahead-options-list-template',
+  templateUrl: './options-list-template.html'
+})
+export class DemoTypeaheadOptionsListTemplateComponent {
+  isBs3 = isBs3();
+
+  selected: string;
+  states: string[] = [
+    'Alabama',
+    'Alaska',
+    'Arizona',
+    'Arkansas',
+    'California',
+    'Colorado',
+    'Connecticut',
+    'Delaware',
+    'Florida',
+    'Georgia',
+    'Hawaii',
+    'Idaho',
+    'Illinois',
+    'Indiana',
+    'Iowa',
+    'Kansas',
+    'Kentucky',
+    'Louisiana',
+    'Maine',
+    'Maryland',
+    'Massachusetts',
+    'Michigan',
+    'Minnesota',
+    'Mississippi',
+    'Missouri',
+    'Montana',
+    'Nebraska',
+    'Nevada',
+    'New Hampshire',
+    'New Jersey',
+    'New Mexico',
+    'New York',
+    'North Dakota',
+    'North Carolina',
+    'Ohio',
+    'Oklahoma',
+    'Oregon',
+    'Pennsylvania',
+    'Rhode Island',
+    'South Carolina',
+    'South Dakota',
+    'Tennessee',
+    'Texas',
+    'Utah',
+    'Vermont',
+    'Virginia',
+    'Washington',
+    'West Virginia',
+    'Wisconsin',
+    'Wyoming'
+  ];
+}

--- a/demo/src/app/components/+typeahead/typeahead-section.list.ts
+++ b/demo/src/app/components/+typeahead/typeahead-section.list.ts
@@ -18,6 +18,7 @@ import { DemoTypeaheadMinLengthComponent } from './demos/min-length/min-length';
 import { DemoTypeaheadNoResultComponent } from './demos/no-result/no-result';
 import { DemoTypeaheadOnBlurComponent } from './demos/on-blur/on-blur';
 import { DemoTypeaheadOnSelectComponent } from './demos/on-select/on-select';
+import { DemoTypeaheadOptionsListTemplateComponent } from './demos/options-list-template/options-list-template';
 import { DemoTypeaheadPhraseDelimitersComponent } from './demos/phrase-delimiters/phrase-delimiters';
 import { DemoTypeaheadReactiveFormComponent } from './demos/reactive-form/reactive-form';
 import { DemoTypeaheadScrollableComponent } from './demos/scrollable/scrollable';
@@ -74,6 +75,13 @@ export const demoComponentContent: ContentSection[] = [
         component: require('!!raw-loader!./demos/item-template/item-template.ts'),
         html: require('!!raw-loader!./demos/item-template/item-template.html'),
         outlet: DemoTypeaheadItemTemplateComponent
+      },
+      {
+        title: 'Options list template',
+        anchor: 'options-list-template',
+        component: require('!!raw-loader!./demos/options-list-template/options-list-template.ts'),
+        html: require('!!raw-loader!./demos/options-list-template/options-list-template.html'),
+        outlet: DemoTypeaheadOptionsListTemplateComponent
       },
       {
         title: 'Option field',
@@ -233,7 +241,7 @@ export const demoComponentContent: ContentSection[] = [
         title: 'Show results on blur',
         anchor: 'show-on-blur',
         description: `
-          <p>Use input property <code>typeaheadHideResultsOnBlur</code> or config property <code>hideResultsOnBlur</code> 
+          <p>Use input property <code>typeaheadHideResultsOnBlur</code> or config property <code>hideResultsOnBlur</code>
           to prevent hiding typeahead's results until a user doesn't choose an item</p>
         `,
         component: require('!!raw-loader!./demos/show-on-blur/show-on-blur.ts'),

--- a/src/typeahead/typeahead-container.component.html
+++ b/src/typeahead/typeahead-container.component.html
@@ -1,6 +1,6 @@
 <!-- inject options list template -->
 <ng-template [ngTemplateOutlet]="optionsListTemplate || (isBs4 ? bs4Template : bs3Template)"
-             [ngTemplateOutletContext]="{matches:matches, itemTemplate:itemTemplate, query:query}"></ng-template>
+             [ngTemplateOutletContext]="{matches:matches, itemTemplate: itemTemplate || bsItemTemplate, query:query, $implicit: this}"></ng-template>
 
 <!-- default options item template -->
 <ng-template #bsItemTemplate let-match="match" let-query="query"><span [innerHtml]="highlight(match, query)"></span>


### PR DESCRIPTION
Allow optionsListTemplate to access typeahead-container's functions, things like `selectActive()` and `selectMatch()` to make optionsListTemplate useful in more scenarios.

Also includes Demo for optionsListTemplate

Similar PR (stale): #4751 
Closes #4036, #3081

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [X] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [X] added/updated demos.