### PR TITLE
targetOffsets as any

### DIFF
--- a/src/positioning/modifiers/arrow.ts
+++ b/src/positioning/modifiers/arrow.ts
@@ -22,7 +22,7 @@ export function arrow(data: Data) {
 
   // top/left side
   if (data.offsets.host[opSide] - arrowElementSize < (targetOffsets as any)[side]) {
-    (targetOffsets as any)[side] -=
+    (targetOffsets as any)[side]-=
       (targetOffsets as any)[side] - (data.offsets.host[opSide] - arrowElementSize);
   }
   // bottom/right side


### PR DESCRIPTION
src/positioning/modifiers/arrow.ts (Line 25)
    (targetOffsets as any)[side] -=
Property '(targetOffsets as any)[side]' is used on both the left and right sides of this compound assignment. Consider using non-compound assignment instead.
A reference is used on both sides of compound assignment operator
This rule applies when a reference is used on both sides of compound assignment operator.

If there is a same reference on both sides of compound assignment operator, the compound operator applies to the reference itself.

It may be typo or intention. But it is recommended to use clearer and shorter code

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [ ] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [ ] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
