### PR TITLE
fix(typeahead): fix broken typeahead property

### DIFF
--- a/src/typeahead/typeahead-container.component.ts
+++ b/src/typeahead/typeahead-container.component.ts
@@ -28,7 +28,7 @@ import { Subscription } from 'rxjs';
     class: 'dropdown open bottom',
     '[class.dropdown-menu]': 'isBs4',
     '[style.height]': `isBs4 && needScrollbar ? guiHeight: 'auto'`,
-    '[style.visibility]': 'hidden',
+    '[style.visibility]': `hidden`,
     '[class.dropup]': 'dropup',
     style: 'position: absolute;display: block;'
   },


### PR DESCRIPTION
Should fix broken build issue, which was found in https://github.com/valor-software/ngx-bootstrap/pull/5589