### PR TITLE
fix(typeahead): fix broken typeahead property

### DIFF
--- a/src/typeahead/typeahead-container.component.ts
+++ b/src/typeahead/typeahead-container.component.ts
@@ -28,7 +28,7 @@ import { Subscription } from 'rxjs';
     class: 'dropdown open bottom',
     '[class.dropdown-menu]': 'isBs4',
     '[style.height]': `isBs4 && needScrollbar ? guiHeight: 'auto'`,
-    '[style.visibility]': 'hidden',
+    '[style.visibility]': `'inherit'`,
     '[class.dropup]': 'dropup',
     style: 'position: absolute;display: block;'
   },


### PR DESCRIPTION
Rebased from commit after 5.4.0 release

Should fix broken typeahead property, which was found in #5589