### PR TITLE
fix(datepicker): datepicker not closed on Enter click in IE11

### DIFF
--- a/src/datepicker/bs-datepicker-input.directive.ts
+++ b/src/datepicker/bs-datepicker-input.directive.ts
@@ -50,6 +50,7 @@ const BS_DATEPICKER_VALIDATOR: Provider = {
   host: {
     '(change)': 'onChange($event)',
     '(keyup.esc)': 'hide()',
+    '(keydown)': 'onKeydownEvent($event)',
     '(blur)': 'onBlur()'
   },
   providers: [BS_DATEPICKER_VALUE_ACCESSOR, BS_DATEPICKER_VALIDATOR]
@@ -95,6 +96,12 @@ export class BsDatepickerInputDirective
     this._localeService.localeChange.subscribe(() => {
       this._setInputValue(this._value);
     });
+  }
+
+  onKeydownEvent(event) {
+    if (event.keyCode === 13 || event.code === 'Enter') {
+      this.hide();
+    }
   }
 
   _setInputValue(value: Date): void {

--- a/src/datepicker/bs-daterangepicker-input.directive.ts
+++ b/src/datepicker/bs-daterangepicker-input.directive.ts
@@ -51,6 +51,7 @@ const BS_DATERANGEPICKER_VALIDATOR: Provider = {
   host: {
     '(change)': 'onChange($event)',
     '(keyup.esc)': 'hide()',
+    '(keydown)': 'onKeydownEvent($event)',
     '(blur)': 'onBlur()'
   },
   providers: [BS_DATERANGEPICKER_VALUE_ACCESSOR, BS_DATERANGEPICKER_VALIDATOR]
@@ -97,6 +98,12 @@ export class BsDaterangepickerInputDirective
     this._localeService.localeChange.subscribe(() => {
       this._setInputValue(this._value);
     });
+  }
+
+  onKeydownEvent(event) {
+    if (event.keyCode === 13 || event.code === 'Enter') {
+      this.hide();
+    }
   }
 
   _setInputValue(date: Date[]): void {


### PR DESCRIPTION
closes #5617
On Google Chrome and Firefox this functionality worked before, but, I also checked this code in them no issues were caused by this condition.


# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
