### PR TITLE
fix(typeahead): add typing for typeahead source data

### DIFF
--- a/demo/src/ng-api-doc.ts
+++ b/demo/src/ng-api-doc.ts
@@ -3869,7 +3869,7 @@ export const ngdoc: any = {
       },
       {
         "name": "typeahead",
-        "type": "any",
+        "type": "Typeahead",
         "description": "<p>options source, can be Array of strings, objects or\nan Observable for external matching process</p>\n"
       },
       {


### PR DESCRIPTION
Add typing for typeahead source data

### Please merge only after this PR #5646

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
