### PR TITLE
fix: assign positioning options per element (#5668)

### DIFF
--- a/src/component-loader/component-loader.class.ts
+++ b/src/component-loader/component-loader.class.ts
@@ -86,6 +86,8 @@ export class ComponentLoader<T> {
   private _listenOpts: ListenOptions = {};
   private _globalListener = Function.prototype;
 
+  private _posOpts: PositioningOptions['options'];
+
   /**
    * Do not use this directly, it should be instanced via
    * `ComponentLoadFactory.attach`
@@ -117,10 +119,11 @@ export class ComponentLoader<T> {
     return this;
   }
 
-  position(opts?: PositioningOptions): ComponentLoader<T> {
+  position(opts: PositioningOptions): ComponentLoader<T> {
     this.attachment = opts.attachment || this.attachment;
     /* tslint:disable-next-line: no-unnecessary-type-assertion */
     this._elementRef = (opts.target as ElementRef) || this._elementRef;
+    this._posOpts = opts.options;
 
     return this;
   }
@@ -347,7 +350,8 @@ export class ComponentLoader<T> {
         element: this._componentRef.location,
         target: this._elementRef,
         attachment: this.attachment,
-        appendToBody: this.container === 'body'
+        appendToBody: this.container === 'body',
+        options: this._posOpts
       });
     });
 

--- a/src/datepicker/bs-datepicker.component.ts
+++ b/src/datepicker/bs-datepicker.component.ts
@@ -206,7 +206,13 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges, Afte
       .provide({provide: BsDatepickerConfig, useValue: this._config})
       .attach(BsDatepickerContainerComponent)
       .to(this.container)
-      .position({attachment: this.placement})
+      .position({
+        attachment: this.placement,
+        options: {
+          modifiers: { flip: { enabled: this._config.adaptivePosition } },
+          allowedPositions: ['top', 'bottom']
+        }
+      })
       .show({placement: this.placement});
 
     // if date changes from external source (model -> view)

--- a/src/datepicker/bs-daterangepicker.component.ts
+++ b/src/datepicker/bs-daterangepicker.component.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-file-line-count
 import {
   AfterViewInit,
   ComponentRef,
@@ -213,7 +214,13 @@ export class BsDaterangepickerDirective
       .provide({ provide: BsDatepickerConfig, useValue: this._config })
       .attach(BsDaterangepickerContainerComponent)
       .to(this.container)
-      .position({ attachment: this.placement })
+      .position({
+        attachment: this.placement,
+        options: {
+          modifiers: { flip: { enabled: this._config.adaptivePosition } },
+          allowedPositions: ['top', 'bottom']
+        }
+      })
       .show({ placement: this.placement });
 
     // if date changes from external source (model -> view)

--- a/src/datepicker/themes/bs/bs-datepicker-container.component.ts
+++ b/src/datepicker/themes/bs/bs-datepicker-container.component.ts
@@ -52,11 +52,6 @@ export class BsDatepickerContainerComponent extends BsDatepickerAbstractComponen
   }
 
   ngOnInit(): void {
-    this._positionService.setOptions({
-      modifiers: { flip: { enabled: this._config.adaptivePosition } },
-      allowedPositions: ['top', 'bottom']
-    });
-
     this._positionService.event$
       .pipe(
         take(1)

--- a/src/datepicker/themes/bs/bs-daterangepicker-container.component.ts
+++ b/src/datepicker/themes/bs/bs-daterangepicker-container.component.ts
@@ -57,11 +57,6 @@ export class BsDaterangepickerContainerComponent extends BsDatepickerAbstractCom
   }
 
   ngOnInit(): void {
-    this._positionService.setOptions({
-      modifiers: { flip: { enabled: this._config.adaptivePosition } },
-      allowedPositions: ['top', 'bottom']
-    });
-
     this._positionService.event$
       .pipe(
         take(1)

--- a/src/popover/popover.directive.ts
+++ b/src/popover/popover.directive.ts
@@ -135,7 +135,7 @@ export class PopoverDirective implements OnInit, OnDestroy {
       return;
     }
 
-    this._positionService.setOptions({
+    const posOpts = {
       modifiers: {
         flip: {
           enabled: this.adaptivePosition
@@ -144,7 +144,7 @@ export class PopoverDirective implements OnInit, OnDestroy {
           enabled: this.adaptivePosition
         }
       }
-    });
+    };
 
     const showPopover = () => {
       if (this._delayTimeoutId) {
@@ -154,7 +154,10 @@ export class PopoverDirective implements OnInit, OnDestroy {
       this._popover
         .attach(PopoverContainerComponent)
         .to(this.container)
-        .position({attachment: this.placement})
+        .position({
+          attachment: this.placement,
+          options: posOpts
+        })
         .show({
           content: this.popover,
           context: this.popoverContext,

--- a/src/positioning/positioning.service.ts
+++ b/src/positioning/positioning.service.ts
@@ -38,12 +38,14 @@ export interface PositioningOptions {
 
   /** If true component will be attached to body */
   appendToBody?: boolean;
+
+  /** Additional positioning options */
+  options?: Options;
 }
 
 
 @Injectable()
 export class PositioningService {
-  private options: Options;
   private update$$ = new Subject<null>();
   private positionElements = new Map();
   private triggerEvent$: Observable<number|Event>;
@@ -78,7 +80,7 @@ export class PositioningService {
                 _getHtmlElement(positionElement.element),
                 positionElement.attachment,
                 positionElement.appendToBody,
-                this.options,
+                positionElement.options,
                 rendererFactory.createRenderer(null, null)
               );
             });
@@ -113,10 +115,6 @@ export class PositioningService {
 
   deletePositionElement(elRef: ElementRef): void {
     this.positionElements.delete(_getHtmlElement(elRef));
-  }
-
-  setOptions(options: Options) {
-    this.options = options;
   }
 }
 

--- a/src/tooltip/tooltip.directive.ts
+++ b/src/tooltip/tooltip.directive.ts
@@ -17,7 +17,6 @@ import { TooltipConfig } from './tooltip.config';
 
 import { ComponentLoader, ComponentLoaderFactory } from 'ngx-bootstrap/component-loader';
 import { OnChange, warnOnce, parseTriggers, Trigger } from 'ngx-bootstrap/utils';
-import { PositioningService } from 'ngx-bootstrap/positioning';
 
 import { timer, Subscription } from 'rxjs';
 
@@ -210,8 +209,7 @@ export class TooltipDirective implements OnInit, OnDestroy {
     cis: ComponentLoaderFactory,
     config: TooltipConfig,
     private _elementRef: ElementRef,
-    private _renderer: Renderer2,
-    private _positionService: PositioningService
+    private _renderer: Renderer2
   ) {
 
     this._tooltip = cis
@@ -275,7 +273,7 @@ export class TooltipDirective implements OnInit, OnDestroy {
    * the tooltip.
    */
   show(): void {
-    this._positionService.setOptions({
+    const posOpts = {
       modifiers: {
         flip: {
           enabled: this.adaptivePosition
@@ -284,7 +282,7 @@ export class TooltipDirective implements OnInit, OnDestroy {
           enabled: this.adaptivePosition
         }
       }
-    });
+    };
 
     if (
       this.isOpen ||
@@ -303,7 +301,10 @@ export class TooltipDirective implements OnInit, OnDestroy {
       this._tooltip
         .attach(TooltipContainerComponent)
         .to(this.container)
-        .position({attachment: this.placement})
+        .position({
+          attachment: this.placement,
+          options: posOpts
+        })
         .show({
           content: this.tooltip,
           placement: this.placement,

--- a/src/typeahead/typeahead-container.component.ts
+++ b/src/typeahead/typeahead-container.component.ts
@@ -87,12 +87,12 @@ export class TypeaheadContainerComponent implements OnDestroy {
   private liElements: QueryList<ElementRef>;
 
   constructor(
-    private positionService: PositioningService,
+    positionService: PositioningService,
     private renderer: Renderer2,
     public element: ElementRef,
     private changeDetectorRef: ChangeDetectorRef
   ) {
-    this.positionServiceSubscription = this.positionService.event$.subscribe(
+    this.positionServiceSubscription = positionService.event$.subscribe(
       () => {
         if (this.isAnimated) {
           this.animationState = this.isTopPosition ? 'animated-up' : 'animated-down';
@@ -116,11 +116,6 @@ export class TypeaheadContainerComponent implements OnDestroy {
   }
 
   set matches(value: TypeaheadMatch[]) {
-    this.positionService.setOptions({
-      modifiers: { flip: { enabled: this.adaptivePosition } },
-      allowedPositions: ['top', 'bottom']
-    });
-
     this._matches = value;
 
     this.needScrollbar = this.typeaheadScrollable && this.typeaheadOptionsInScrollableView < this.matches.length;
@@ -163,10 +158,6 @@ export class TypeaheadContainerComponent implements OnDestroy {
 
   get isAnimated(): boolean {
     return this.parent ? this.parent.isAnimated : false;
-  }
-
-  get adaptivePosition(): boolean {
-    return this.parent ? this.parent.adaptivePosition : false;
   }
 
   get typeaheadScrollable(): boolean {

--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -344,7 +344,13 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
     this._typeahead
       .attach(TypeaheadContainerComponent)
       .to(this.container)
-      .position({attachment: `${this.dropup ? 'top' : 'bottom'} start`})
+      .position({
+        attachment: `${this.dropup ? 'top' : 'bottom'} start`,
+        options: {
+          modifiers: { flip: { enabled: this.adaptivePosition } },
+          allowedPositions: ['top', 'bottom']
+        }
+      })
       .show({
         typeaheadRef: this,
         placement: this.placement,


### PR DESCRIPTION

Fixes #5668 
save positioning options per element to prevent overrides

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.

---
Hi! I opened #5668 a couple of weeks ago, and this is my attempt at fixing it.
I noticed the options related to adaptive positioning were saved in a single property in the positioning service [here](https://github.com/valor-software/ngx-bootstrap/blob/b405057af01a06b56e53f1bfe5a6d55dfa047ef1/src/positioning/positioning.service.ts#L46) . As a result, every time there were two components open, those options were overridden by the last one. So, my idea was to save the options separately for each component.
Any suggestions are welcome (should I add tests or demos?).