### PR TITLE
fix(typeahead): add variable which was missed in MR #5547

### DIFF
--- a/scripts/ci/npm-ng-latest.sh
+++ b/scripts/ci/npm-ng-latest.sh
@@ -18,6 +18,6 @@ npm i @angular/animations@latest \
     @angular/service-worker@latest \
     @schematics/angular@latest \
     @types/node@latest \
-    typescript@3.7.5 \
+    typescript@3.8 \
     tsickle@0.35.0 \
     rxjs@6.5.2

--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -151,6 +151,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
 
   activeDescendant: string;
   isOpen = false;
+  list = 'list';
   _container: TypeaheadContainerComponent;
   isActiveItemChanged = false;
   isFocused = false;


### PR DESCRIPTION
adding variable `list` which was added in host Object as `[attr.aria-autocomplete]: 'list'` but was not defined.
Modules/Libraries which uses AoT compilation for their build gets fatal error due to this.

this will fix let AoT builds to work properly which was introduced in MR https://github.com/valor-software/ngx-bootstrap/pull/5547

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
