### PR TITLE
Switch to generic ModuleWithProviders

### DIFF
--- a/src/accordion/accordion.module.ts
+++ b/src/accordion/accordion.module.ts
@@ -13,7 +13,7 @@ import { CollapseModule } from 'ngx-bootstrap/collapse';
   exports: [AccordionComponent, AccordionPanelComponent]
 })
 export class AccordionModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<AccordionModule> {
     return { ngModule: AccordionModule, providers: [AccordionConfig] };
   }
 }

--- a/src/alert/alert.module.ts
+++ b/src/alert/alert.module.ts
@@ -10,7 +10,7 @@ import { AlertConfig } from './alert.config';
   entryComponents: [AlertComponent]
 })
 export class AlertModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<AlertModule> {
     return { ngModule: AlertModule, providers: [AlertConfig] };
   }
 }

--- a/src/buttons/buttons.module.ts
+++ b/src/buttons/buttons.module.ts
@@ -9,7 +9,7 @@ import { ButtonRadioGroupDirective } from './button-radio-group.directive';
   exports: [ButtonCheckboxDirective, ButtonRadioDirective, ButtonRadioGroupDirective]
 })
 export class ButtonsModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<ButtonsModule> {
     return { ngModule: ButtonsModule, providers: [] };
   }
 }

--- a/src/carousel/carousel.module.ts
+++ b/src/carousel/carousel.module.ts
@@ -12,7 +12,7 @@ import { CarouselConfig } from './carousel.config';
   providers: [CarouselConfig]
 })
 export class CarouselModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<CarouselModule> {
     return { ngModule: CarouselModule, providers: [] };
   }
 }

--- a/src/collapse/collapse.module.ts
+++ b/src/collapse/collapse.module.ts
@@ -7,7 +7,7 @@ import { CollapseDirective } from './collapse.directive';
   exports: [CollapseDirective]
 })
 export class CollapseModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<CollapseModule> {
     return { ngModule: CollapseModule, providers: [] };
   }
 }

--- a/src/datepicker/bs-datepicker.module.ts
+++ b/src/datepicker/bs-datepicker.module.ts
@@ -79,7 +79,7 @@ import { BsYearsCalendarViewComponent } from './themes/bs/bs-years-calendar-view
   ]
 })
 export class BsDatepickerModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<BsDatepickerModule> {
     return {
       ngModule: BsDatepickerModule,
       providers: [

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -28,7 +28,7 @@ import { YearPickerComponent } from './yearpicker.component';
   entryComponents: [DatePickerComponent]
 })
 export class DatepickerModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<DatepickerModule> {
     return { ngModule: DatepickerModule, providers: [DatepickerConfig] };
   }
 }

--- a/src/dropdown/bs-dropdown.module.ts
+++ b/src/dropdown/bs-dropdown.module.ts
@@ -26,7 +26,7 @@ import { BsDropdownState } from './bs-dropdown.state';
 })
 export class BsDropdownModule {
   // tslint:disable-next-line:no-any
-  static forRoot(config?: any): ModuleWithProviders {
+  static forRoot(config?: any): ModuleWithProviders<BsDropdownModule> {
     return {
       ngModule: BsDropdownModule,
       providers: [

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -17,13 +17,13 @@ import { BsModalService } from './bs-modal.service';
   entryComponents: [ModalBackdropComponent, ModalContainerComponent]
 })
 export class ModalModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<ModalModule> {
     return {
       ngModule: ModalModule,
       providers: [BsModalService, ComponentLoaderFactory, PositioningService]
     };
   }
-  static forChild(): ModuleWithProviders {
+  static forChild(): ModuleWithProviders<ModalModule> {
     return {
       ngModule: ModalModule,
       providers: [BsModalService, ComponentLoaderFactory, PositioningService]

--- a/src/pagination/pagination.module.ts
+++ b/src/pagination/pagination.module.ts
@@ -11,7 +11,7 @@ import { PaginationComponent } from './pagination.component';
   exports: [PagerComponent, PaginationComponent]
 })
 export class PaginationModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<PaginationModule> {
     return { ngModule: PaginationModule, providers: [PaginationConfig] };
   }
 }

--- a/src/popover/popover.module.ts
+++ b/src/popover/popover.module.ts
@@ -14,7 +14,7 @@ import { PopoverContainerComponent } from './popover-container.component';
   entryComponents: [PopoverContainerComponent]
 })
 export class PopoverModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<PopoverModule> {
     return {
       ngModule: PopoverModule,
       providers: [PopoverConfig, ComponentLoaderFactory, PositioningService]

--- a/src/progressbar/progressbar.module.ts
+++ b/src/progressbar/progressbar.module.ts
@@ -11,7 +11,7 @@ import { ProgressbarConfig } from './progressbar.config';
   exports: [BarComponent, ProgressbarComponent]
 })
 export class ProgressbarModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<ProgressbarModule> {
     return { ngModule: ProgressbarModule, providers: [ProgressbarConfig] };
   }
 }

--- a/src/rating/rating.module.ts
+++ b/src/rating/rating.module.ts
@@ -10,7 +10,7 @@ import { RatingConfig } from './rating.config';
   exports: [RatingComponent]
 })
 export class RatingModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<RatingModule> {
     return {
       ngModule: RatingModule,
       providers: [RatingConfig]

--- a/src/sortable/sortable.module.ts
+++ b/src/sortable/sortable.module.ts
@@ -10,7 +10,7 @@ import { DraggableItemService } from './draggable-item.service';
   exports: [SortableComponent]
 })
 export class SortableModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<SortableModule> {
     return { ngModule: SortableModule, providers: [DraggableItemService] };
   }
 }

--- a/src/tabs/tabs.module.ts
+++ b/src/tabs/tabs.module.ts
@@ -23,7 +23,7 @@ import { TabsetConfig } from './tabset.config';
   ]
 })
 export class TabsModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<TabsModule> {
     return {
       ngModule: TabsModule,
       providers: [TabsetConfig]

--- a/src/timepicker/timepicker.module.ts
+++ b/src/timepicker/timepicker.module.ts
@@ -12,7 +12,7 @@ import { TimepickerStore } from './reducer/timepicker.store';
   exports: [TimepickerComponent]
 })
 export class TimepickerModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<TimepickerModule> {
     return {
       ngModule: TimepickerModule,
       providers: [TimepickerConfig, TimepickerActions, TimepickerStore]

--- a/src/tooltip/tooltip.module.ts
+++ b/src/tooltip/tooltip.module.ts
@@ -13,7 +13,7 @@ import { PositioningService } from 'ngx-bootstrap/positioning';
   entryComponents: [TooltipContainerComponent]
 })
 export class TooltipModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<TooltipModule> {
     return {
       ngModule: TooltipModule,
       providers: [TooltipConfig, ComponentLoaderFactory, PositioningService]

--- a/src/typeahead/typeahead.module.ts
+++ b/src/typeahead/typeahead.module.ts
@@ -14,7 +14,7 @@ import { TypeaheadConfig } from './typeahead.config';
   entryComponents: [TypeaheadContainerComponent]
 })
 export class TypeaheadModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): ModuleWithProviders<TypeaheadModule> {
     return {
       ngModule: TypeaheadModule,
       providers: [ComponentLoaderFactory, PositioningService, TypeaheadConfig]


### PR DESCRIPTION
- For Ivy compatibility per: https://angular.io/guide/migration-module-with-providers

This simply switched to returning the generic version of ModuleWithProviders.  According to the version compatibility chart, ngx-bootstrap is compatible with angular 7+ and the generic ModuleWithProviders<> was added in Angular 7.

I ran tests locally and saw no issues.  I'm submitting this because I'm getting some build errors when I try to build one of my internal libraries targeting Ivy.

Signed-off-by: Jon Stelly <967068+jonstelly@users.noreply.github.com>

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated tests.
 - [x] added/updated API documentation.
 - [x] added/updated demos.
