### PR TITLE
increase z-index of bs-dropdown-container

### DIFF
--- a/src/dropdown/bs-dropdown-container.component.ts
+++ b/src/dropdown/bs-dropdown-container.component.ts
@@ -17,7 +17,7 @@ import { AnimationBuilder, AnimationFactory } from '@angular/animations';
   selector: 'bs-dropdown-container',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    style: 'display:block;position: absolute;z-index: 1040'
+    style: 'display:block;position: absolute;z-index: 1050'
   },
   template: `
     <div [class.dropup]="direction === 'up'"


### PR DESCRIPTION
In newest version of bootstrap, modal uses z-index 1050 and dropdown container was hidden under modal. With z-index: 1050 it works fine.