### PR TITLE
fix(typeahead): fix accessability arias

### DIFF
--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -34,8 +34,8 @@ type Typeahead = TypeaheadOption[] | Observable<TypeaheadOption[]>;
   exportAs: 'bs-typeahead',
   host: {
     '[attr.aria-activedescendant]': 'activeDescendant',
-    '[attr.aria-aria-owns]': 'isOpen ? this._container.popupId : null',
-    '[attr.aria-aria-expanded]': 'isOpen',
+    '[attr.aria-owns]': 'isOpen ? this._container.popupId : null',
+    '[attr.aria-expanded]': 'isOpen',
     '[attr.aria-autocomplete]': 'list'
   }
 })


### PR DESCRIPTION
Fixes #5880 and fixes #5881 

These changes were made in https://github.com/valor-software/ngx-bootstrap/pull/5547 , and was similar to https://github.com/ng-bootstrap/ng-bootstrap/commit/e1fa7a493cfca4677992c7fc60961f19323b829d#diff-4b999ef7b06784feb23d420f3d909d1aR78 , but, some double typing has been done

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
