### PR TITLE
Handle error with undefined in field _matches in onblur

### DIFF
--- a/src/typeahead/typeahead.directive.ts
+++ b/src/typeahead/typeahead.directive.ts
@@ -321,7 +321,7 @@ export class TypeaheadDirective implements OnInit, OnDestroy {
       this.typeaheadOnBlur.emit(this._container.active);
     }
 
-    if (!this.container && this._matches.length === 0) {
+    if (!this.container && (!this._matches || this._matches.length === 0)) {
     this.typeaheadOnBlur.emit(new TypeaheadMatch(
       this.element.nativeElement.value,
       this.element.nativeElement.value,


### PR DESCRIPTION
I'm having issues using ngx-bootstrap with typeahead module. An error is logged to console.
We are using it together with typeaheadMinLength=2 setting.
I'm not sure, how it could ever get undefined, but it is.

```
logger.service.ts:23 TypeError: Cannot read property 'length' of undefined
    at TypeaheadDirective.onBlur (ngx-bootstrap-typeahead.js:2010)
    at TypeaheadDirective_blur_HostBindingHandler (ngx-bootstrap-typeahead.js:2394)
    at executeListenerWithErrorHandling (core.js:14415)
    at wrapListenerIn_markDirtyAndPreventDefault (core.js:14456)
    at HTMLInputElement.<anonymous> (platform-browser.js:582)
    at ZoneDelegate.invokeTask (zone-evergreen.js:399)
    at Object.onInvokeTask (core.js:27136)
    at ZoneDelegate.invokeTask (zone-evergreen.js:398)
    at Zone.runTask (zone-evergreen.js:167)
    at ZoneTask.invokeTask [as invoke] (zone-evergreen.js:480)
```

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [ ] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [ ] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
