### PR TITLE
fix: don't ship an Ivy compiled library

### DIFF
--- a/scripts/ng-packagr/tsconfig.ngc.json
+++ b/scripts/ng-packagr/tsconfig.ngc.json
@@ -1,9 +1,11 @@
 {
   "angularCompilerOptions": {
+    "enableIvy": false,
+    "disableExpressionLowering": true,
     "annotateForClosureCompiler": true,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
-    "fullTemplateTypeCheck": false,
+    "fullTemplateTypeCheck": true,
     "enableResourceInlining": true
   },
   "buildOnSave": false,


### PR DESCRIPTION
Shipping as Ivy compiled is not recommended by Angular it it breaks
every library that has a dependency on ngx-bootstrap and that does
not ship as Ivy  compiled.

Enabling "fullTemplateTypeCheck" also works around an Angular compiler
problem regarding the `forRoot()` not working..

See #5862

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
