### PR TITLE
chore(modal): expose global config interface (#5719)

### DIFF
--- a/scripts/ci/npm-ng-latest.sh
+++ b/scripts/ci/npm-ng-latest.sh
@@ -18,7 +18,7 @@ npm i @angular/animations@latest \
     @angular/service-worker@latest \
     @schematics/angular@latest \
     @types/node@latest \
-    typescript@3.9 \
+    typescript@4.0.2 \
     ng-packagr@10.0.0 \
     tsickle@0.35.0 \
     rxjs@6.5.2

--- a/scripts/ci/npm-ng-next.sh
+++ b/scripts/ci/npm-ng-next.sh
@@ -17,7 +17,7 @@ npm i @angular/animations@next \
     @angular/service-worker@next \
     @schematics/angular@next \
     @types/node@14.0.4 \
-    typescript@3.9.3 \
+    typescript@4.0.2 \
     ng-packagr@10.0.0 \
     tsickle@0.35.0 \
     rxjs@6.5.2

--- a/src/modal/public_api.ts
+++ b/src/modal/public_api.ts
@@ -2,7 +2,7 @@ export { BsModalRef } from './bs-modal-ref.service';
 export { ModalBackdropOptions } from './modal-backdrop.options';
 export { ModalContainerComponent } from './modal-container.component';
 export { ModalBackdropComponent } from './modal-backdrop.component';
-export { ModalOptions } from './modal-options.class';
+export { ModalOptions, MODAL_CONFIG_DEFAULT_OVERRIDE } from './modal-options.class';
 export { ModalDirective } from './modal.directive';
 export { ModalModule } from './modal.module';
 export { BsModalService } from './bs-modal.service';


### PR DESCRIPTION
This PR is to address a missed interface exposure in #5719 feature.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
