### PR TITLE
fix(ci): fix latest & next builds 'Unknown ver 76 of Android' error

### DIFF
--- a/scripts/ci/npm-ng-latest.sh
+++ b/scripts/ci/npm-ng-latest.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 npm i @angular/animations@latest \
+    @angular-devkit/build-angular@latest \
     @angular-devkit/core@latest \
     @angular-devkit/schematics@latest \
     @angular/cli@latest \
@@ -9,7 +10,6 @@ npm i @angular/animations@latest \
     @angular/compiler@latest \
     @angular/core@latest \
     @angular/forms@latest \
-    @angular/http@latest \
     @angular/language-service@latest \
     @angular/platform-browser-dynamic@latest \
     @angular/platform-browser@latest \
@@ -18,6 +18,7 @@ npm i @angular/animations@latest \
     @angular/service-worker@latest \
     @schematics/angular@latest \
     @types/node@latest \
+    caniuse-lite@latest \
     typescript@4.0.2 \
     ng-packagr@10.0.0 \
     tsickle@0.35.0 \

--- a/scripts/ci/npm-ng-next.sh
+++ b/scripts/ci/npm-ng-next.sh
@@ -2,6 +2,7 @@
 
 npm i @angular/animations@next \
     @angular/core@next \
+    @angular-devkit/build-angular@next \
     @angular-devkit/core@next \
     @angular-devkit/schematics@next \
     @angular/cli@next \
@@ -17,6 +18,7 @@ npm i @angular/animations@next \
     @angular/service-worker@next \
     @schematics/angular@next \
     @types/node@14.0.4 \
+    caniuse-lite@latest \
     typescript@4.0.2 \
     ng-packagr@10.0.0 \
     tsickle@0.35.0 \


### PR DESCRIPTION
# PR Checklist

Fixes

```
Building rating module
Build of rating module completed
Building sortable module
Build of sortable module completed
Building tabs module
Error: Command failed: /bin/sh -c rimraf dist/tabs && node scripts/ng-packagr/api ../../src/tabs/package.json
Browserslist: caniuse-lite is outdated. Please run the following command: `npm update`
ERROR: Unknown version 76 of android
Error [BrowserslistError]: Unknown version 76 of android
    at Function.select (/home/travis/build/valor-software/ngx-bootstrap/node_modules/autoprefixer/node_modules/browserslist/index.js:1102:17)
    at /home/travis/build/valor-software/ngx-bootstrap/node_modules/autoprefixer/node_modules/browserslist/index.js:336:33
    at Array.reduce (<anonymous>)
    at resolve (/home/travis/build/valor-software/ngx-bootstrap/node_modules/autoprefixer/node_modules/browserslist/index.js:318:18)
    at browserslist (/home/travis/build/valor-software/ngx-bootstrap/node_modules/autoprefixer/node_modules/browserslist/index.js:444:21)
    at Browsers.parse (/home/travis/build/valor-software/ngx-bootstrap/node_modules/autoprefixer/lib/browsers.js:63:12)
    at new Browsers (/home/travis/build/valor-software/ngx-bootstrap/node_modules/autoprefixer/lib/browsers.js:46:26)
    at loadPrefixes (/home/travis/build/valor-software/ngx-bootstrap/node_modules/autoprefixer/lib/autoprefixer.js:98:20)
    at plugin (/home/travis/build/valor-software/ngx-bootstrap/node_modules/autoprefixer/lib/autoprefixer.js:109:20)
    at LazyResult.run (/home/travis/build/valor-software/ngx-bootstrap/node_modules/ng-packagr/node_modules/postcss/lib/lazy-result.js:288:14) {
  browserslist: true
}
Building Angular Package
------------------------------------------------------------------------------
Building entry point 'ngx-bootstrap/tabs'
------------------------------------------------------------------------------
Compiling TypeScript sources through ngc
    at makeError (/home/travis/build/valor-software/ngx-bootstrap/node_modules/execa/index.js:174:9)
    at /home/travis/build/valor-software/ngx-bootstrap/node_modules/execa/index.js:278:16
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async buildModules (/home/travis/build/valor-software/ngx-bootstrap/scripts/build-modules.js:75:5)
    at async buildAll (/home/travis/build/valor-software/ngx-bootstrap/scripts/build-modules.js:35:3)

```


Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
