### PR TITLE
feat(datepicker): improve manual DateRange input

### DIFF
--- a/src/datepicker/bs-daterangepicker-input.directive.ts
+++ b/src/datepicker/bs-daterangepicker-input.directive.ts
@@ -181,17 +181,20 @@ export class BsDaterangepickerInputDirective
         );
       }
 
-      let _input: (string[] | Date[]) = [];
+      let _input: (string | Date)[] = [];
       if (typeof value === 'string') {
-        _input = value.split(this._picker._config.rangeSeparator);
+        const trimmedSeparator = this._picker._config.rangeSeparator.trim();
+        _input = value
+          .split(trimmedSeparator.length > 0 ? trimmedSeparator : this._picker._config.rangeSeparator)
+          .map(_val => _val.trim());
       }
 
       if (Array.isArray(value)) {
         _input = value;
       }
 
-      this._value = (_input as string[])
-        .map((_val: string): Date => {
+      this._value = _input
+        .map((_val: string | Date): Date => {
             if (this._picker._config.useUtc) {
               return utcAsLocal(
                 parseDate(_val, this._picker._config.rangeInputFormat, this._localeService.currentLocale)


### PR DESCRIPTION
allow the DateRangepicker to ignore missing spaces in manual Input.
eg. Separator ' - ' will be able to read 1.1.2020-1.1.2021

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [ ] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [ ] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
