### PR TITLE
fix(modal): fix the closure of modal when clicking of scrollbar in some browsers

### DIFF
--- a/src/modal/modal-container.component.ts
+++ b/src/modal/modal-container.component.ts
@@ -84,7 +84,7 @@ export class ModalContainerComponent implements OnInit, OnDestroy {
     this.clickStartedInContent = event.target !== this._element.nativeElement;
   }
 
-  @HostListener('mouseup', ['$event'])
+  @HostListener('click', ['$event'])
   onClickStop(event: MouseEvent): void {
     const clickedInBackdrop = event.target === this._element.nativeElement && !this.clickStartedInContent;
     if (


### PR DESCRIPTION
With some combinations of browser & OS (for ex Chrome 87 on MacOS) the scrollbar can appear above the content, and the events `mousedown` & `mouseup` will fire when clicking on it, which triggers the closure of the modal.
As `click` doesn't fire if we click on the scrollbar, replacing `mouseup` by `click` solves the issue (the use of `mousedown` being necessary to fix an other issue about text selection).

Creating tests for this scenario is complicated as the bug appears on specific browsers.

Fixes valor-software#5893 and valor-software#5810

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
