### PR TITLE
fix(collapse): respect display input value

### DIFF
--- a/apps/ngx-bootstrap-docs/src/app/components/+collapse/demos/inline-display/inline-display.html
+++ b/apps/ngx-bootstrap-docs/src/app/components/+collapse/demos/inline-display/inline-display.html
@@ -1,10 +1,10 @@
-<button type="button" class="btn btn-success" (click)="collapse.display='inline-block'"
+<button type="button" class="btn btn-success" (click)="isCollapsed = false"
         aria-controls="collapseBasic">Inline-block
 </button>
-<button type="button" class="btn btn-primary" (click)="collapse.display='none'"
+<button type="button" class="btn btn-primary" (click)="isCollapsed = true"
         aria-controls="collapseBasic">None
 </button>
 <hr>
-<div id="collapseBasic" [collapse]="!isCollapsed" #collapse="bs-collapse">
+<div id="collapseBasic" [collapse]="isCollapsed" [display]="'inline-block'">
   <div class="well well-lg card card-block card-header">Some content</div>
 </div>


### PR DESCRIPTION
This change removes race conditions caused by TypeScript setters being called by Angular in non-deterministic order. Setters side effects (reading values set in other setters) are moved to `ngOnChanges` lifecycle hook. The consequence is that those side effects are no longer called when those inputs are set other than in the template. This is a breaking change but methods to call instead of setting those properties are already provided (`show`/`hide`) so migration path is straightforward. Setting `display` to `'none'` no longer hides the collapse, setting `collapse` input to `true` or calling `hide` method is the way to go.

**BREAKING CHANGE**: setting `display` or `collapse` property on `CollapseDirective` no longer expands/collapses the collapse - use `show`/`hide` methods instead or set `collapse` input in template

No changes in tests since those are currently structured such that I cannot add display property for only one case (there is single shared template). I can restructure the tests to use separate templates (with `overrideComponent`) if you wish (I consider this major change since most likely majority of lines in spec file will be affected) .

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [x] added/updated demos.
