### PR TITLE
Added '@Input () isTimeForNow = true' to avoid setting _bsValue twice…

### DIFF
--- a/src/datepicker/bs-datepicker.component.ts
+++ b/src/datepicker/bs-datepicker.component.ts
@@ -92,6 +92,10 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges, Afte
    */
   @Input() dateTooltipTexts?: DatepickerDateTooltipText[];
   /**
+   * Indicates Time of Date is set to now 
+   */
+  @Input() isTimeForNow = true;
+  /**
    * Emits when datepicker value has been changed
    */
   @Output() bsValueChange: EventEmitter<Date> = new EventEmitter();
@@ -140,7 +144,7 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges, Afte
       return;
     }
 
-    if (!this._bsValue && value) {
+    if (!this._bsValue && value && isTimeForNow) {
       const now = new Date();
 
       value.setMilliseconds(now.getMilliseconds());


### PR DESCRIPTION
… in case of TimePicker is associate with current DatePicker

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [ ] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [ ] built and tested the changes locally.
 - [ ] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
