### PR TITLE
fix(aria-expanded): fixed unnecessary aria-expanded

### DIFF
--- a/apps/ngx-bootstrap-docs-e2e/src/support/collapse.po.ts
+++ b/apps/ngx-bootstrap-docs-e2e/src/support/collapse.po.ts
@@ -19,8 +19,7 @@ export class CollapsePo extends BaseComponent {
 
   isCollapseExpanded(baseSelector: string, expandedAttrValue: string) {
     cy.get(`${ baseSelector } ${ this.collapseClass }`)
-      .should(expandedAttrValue === 'true' ? 'to.have.class' : 'not.to.have.class', this.showIndicator)
-      .and('to.have.attr', 'aria-expanded', expandedAttrValue);
+      .should(expandedAttrValue === 'true' ? 'to.have.class' : 'not.to.have.class', this.showIndicator);
   }
 
   isCollapseWithInline(baseSelector: string, inline: boolean) {

--- a/src/collapse/collapse.directive.ts
+++ b/src/collapse/collapse.directive.ts
@@ -40,7 +40,7 @@ export class CollapseDirective implements AfterViewChecked {
   // shown
   @HostBinding('class.in')
   @HostBinding('class.show')
-  @HostBinding('attr.aria-expanded')
+
   isExpanded = true;
   collapseNewValue = true;
   // hidden

--- a/src/collapse/testing/collapse.directive.spec.ts
+++ b/src/collapse/testing/collapse.directive.spec.ts
@@ -117,13 +117,6 @@ describe('Directive: Collapse', () => {
     expect(element.offsetHeight).toBe(0);
   });
 
-  it('should change aria-expanded attribute', () => {
-    expect(element.getAttribute('aria-expanded')).toBe('true');
-    context.isCollapsed = true;
-    fixture.detectChanges();
-    expect(element.getAttribute('aria-expanded')).toBe('false');
-  });
-
   it('should change aria-hidden attribute', () => {
     expect(element.getAttribute('aria-hidden')).toBe('false');
     context.isCollapsed = true;


### PR DESCRIPTION
The attribute aria-expanded is not necessary on the collapse element (div for example ).
It is use only on the element who control the expanded action.

In link, the list who attribute aria-expanded where can be used
https://www.w3.org/TR/wai-aria-1.1/#aria-expanded

> button
> combobox
> document
> link
> section
> sectionhead
> window

