### PR TITLE
feat(datepicker): prevent overflow if adaptivePosition is set to true

### DIFF
--- a/src/datepicker/bs-datepicker.config.ts
+++ b/src/datepicker/bs-datepicker.config.ts
@@ -183,4 +183,8 @@ export class BsDatepickerConfig implements DatepickerRenderOptions {
    * Set current hours, minutes, seconds and milliseconds for bsValue
    */
   initCurrentTime?: boolean;
+  /**
+   * Set allowed positions of container.
+   */
+  allowedPositions = ['top', 'bottom'];
 }

--- a/src/datepicker/themes/bs/bs-datepicker-container.component.ts
+++ b/src/datepicker/themes/bs/bs-datepicker-container.component.ts
@@ -69,8 +69,15 @@ export class BsDatepickerContainerComponent extends BsDatepickerAbstractComponen
 
   ngOnInit(): void {
     this._positionService.setOptions({
-      modifiers: { flip: { enabled: this._config.adaptivePosition } },
-      allowedPositions: ['top', 'bottom']
+      modifiers: {
+        flip: {
+          enabled: this._config.adaptivePosition
+        },
+        preventOverflow: {
+          enabled: this._config.adaptivePosition
+        }
+      },
+      allowedPositions: this._config.allowedPositions
     });
 
     this._positionService.event$?.pipe(take(1))

--- a/src/datepicker/themes/bs/bs-daterangepicker-container.component.ts
+++ b/src/datepicker/themes/bs/bs-daterangepicker-container.component.ts
@@ -77,8 +77,15 @@ export class BsDaterangepickerContainerComponent extends BsDatepickerAbstractCom
 
   ngOnInit(): void {
     this._positionService.setOptions({
-      modifiers: { flip: { enabled: this._config.adaptivePosition } },
-      allowedPositions: ['top', 'bottom']
+      modifiers: {
+        flip: {
+          enabled: this._config.adaptivePosition
+        },
+        preventOverflow: {
+          enabled: this._config.adaptivePosition
+        }
+      },
+      allowedPositions: this._config.allowedPositions
     });
 
     this._positionService.event$?.pipe(take(1))


### PR DESCRIPTION
## Motivation
If the calendar of `[datepicker]` or `[daterangepicker]` is wider than `<input>` and if <input> is positioned on the very left or right of the viewport, it is likely that the calendar is not completely accessible.

## Solution 
By using modifier `preventOverflow` of `PositioningService` in `bs-datepicker-container.component.ts` and `bs-daterangepicker-container.component.ts` an overflow is prevented. I used the same logic like it was used for `popover.directive.ts` and `tooltip.directive.ts`.

## PR Checklist
 - ✓ read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - ✓ built and tested the changes locally. --> Manual test on local server and automatic test by executing `npm run test`.
 - X added/updated tests.
 - ✓ added/updated API documentation --> see bs-datepicker.config.ts
 - X added/updated demos --> A demo for [adaptive-position](http://localhost:4200/ngx-bootstrap/#/components/datepicker?tab=overview#adaptive-position) exist already .

## Related issue
- https://github.com/valor-software/ngx-bootstrap/issues/5705