### PR TITLE
feat(datepicker): enable to listen for viewchanges

### DIFF
--- a/apps/ngx-bootstrap-docs/src/ng-api-doc.ts
+++ b/apps/ngx-bootstrap-docs/src/ng-api-doc.ts
@@ -838,6 +838,10 @@ export const ngdoc: any = {
       {
         "name": "bsValueChange",
         "description": "<p>Emits when datepicker value has been changed</p>\n"
+      },
+      {
+        "name": "bsViewChange",
+        "description": "<p>Emits when datepicker view has been changed</p>\n"
       }
     ],
     "properties": [],
@@ -970,6 +974,10 @@ export const ngdoc: any = {
       {
         "name": "bsValueChange",
         "description": "<p>Emits when datepicker value has been changed</p>\n"
+      },
+      {
+        "name": "bsViewChange",
+        "description": "<p>Emits when datepicker view has been changed</p>\n"
       },
       {
         "name": "onHidden",
@@ -1389,6 +1397,10 @@ export const ngdoc: any = {
       {
         "name": "bsValueChange",
         "description": "<p>Emits when daterangepicker value has been changed</p>\n"
+      },
+      {
+        "name": "bsViewChange",
+        "description": "<p>Emits when datepicker view has been changed</p>\n"
       },
       {
         "name": "onHidden",

--- a/libs/doc-pages/datepicker/src/lib/datepicker-section.list.ts
+++ b/libs/doc-pages/datepicker/src/lib/datepicker-section.list.ts
@@ -51,6 +51,7 @@ import { DemoDatepickerClearButtonComponent } from './demos/clear-button/clear-b
 import { DemoDatepickerStartViewComponent } from "./demos/start-view/start-view";
 import { DemoDatepickerPreventChangeToNextMonthComponent } from './demos/prevent-change-to-next-month/prevent-change-to-next-month.component';
 import { DemoDatepickerWithTimepickerComponent } from './demos/with-timepicker/with-timepicker';
+import { DemoDatepickerViewChangeEventComponent } from './demos/view-change-event/view-change-event';
 
 export const demoComponentContent: ContentSection[] = [
   {
@@ -319,6 +320,14 @@ export const demoComponentContent: ContentSection[] = [
         html: require('!!raw-loader!./demos/value-change-event/value-change-event.html'),
         description: `<p>You can subscribe to datepicker's value change event (<code>bsValueChange</code>).</p>`,
         outlet: DemoDatepickerValueChangeEventComponent
+      },
+      {
+        title: 'View change event',
+        anchor: 'view-change-event',
+        component: require('!!raw-loader!./demos/view-change-event/view-change-event.ts'),
+        html: require('!!raw-loader!./demos/view-change-event/view-change-event.html'),
+        description: `<p>You can subscribe to datepicker's view change event (<code>bsViewChange</code>).</p>`,
+        outlet: DemoDatepickerViewChangeEventComponent
       },
       {
         title: 'Config properties',
@@ -623,6 +632,11 @@ export const demoComponentContent: ContentSection[] = [
         title: 'Value change event',
         anchor: 'value-change-event-ex',
         outlet: DemoDatepickerValueChangeEventComponent
+      },
+      {
+        title: 'View change event',
+        anchor: 'view-change-event-ex',
+        outlet: DemoDatepickerViewChangeEventComponent
       },
       {
         title: 'Config properties',

--- a/libs/doc-pages/datepicker/src/lib/demos/index.ts
+++ b/libs/doc-pages/datepicker/src/lib/demos/index.ts
@@ -32,6 +32,7 @@ import { DemoDatePickerSelectWeekRangeComponent } from './select-week-range/sele
 import { DemoDatepickerTriggersCustomComponent } from './triggers-custom/triggers-custom';
 import { DemoDatepickerTriggersManualComponent } from './triggers-manual/triggers-manual';
 import { DemoDatepickerValueChangeEventComponent } from './value-change-event/value-change-event';
+import { DemoDatepickerViewChangeEventComponent } from './view-change-event/view-change-event';
 import { DemoDatePickerVisibilityEventsComponent } from './visibility-events/visibility-events';
 import { DemoDatePickerQuickSelectRangesComponent } from './quick-select-ranges/quick-select-ranges';
 import { DemoDateRangePickerShowPreviousMonth } from './daterangepicker-show-previous-month/show-previous-month';
@@ -77,6 +78,7 @@ export const DEMO_COMPONENTS = [
   DemoDatepickerTriggersCustomComponent,
   DemoDatepickerTriggersManualComponent,
   DemoDatepickerValueChangeEventComponent,
+  DemoDatepickerViewChangeEventComponent,
   DemoDateRangePickerShowPreviousMonth,
   DemoDateRangePickerDisplayOneMonth,
   DemoDatePickerVisibilityEventsComponent,

--- a/libs/doc-pages/datepicker/src/lib/demos/view-change-event/view-change-event.html
+++ b/libs/doc-pages/datepicker/src/lib/demos/view-change-event/view-change-event.html
@@ -1,0 +1,12 @@
+<div class="row">
+  <div class="col-xs-12 col-12 col-sm-6 col-md-4 form-group mb-3">
+    <div class="mb-3 card card-block card-header" *ngIf="view">
+        <div class="mb-2"><code>$event.date</code>: {{view.date | date}}</div>
+        <div><code>$event.mode</code>: {{view.mode}}</div>
+    </div>
+    <input class="form-control"
+           placeholder="Datepicker"
+           bsDatepicker
+           (bsViewChange)="onViewChange($event)">
+  </div>
+</div>

--- a/libs/doc-pages/datepicker/src/lib/demos/view-change-event/view-change-event.ts
+++ b/libs/doc-pages/datepicker/src/lib/demos/view-change-event/view-change-event.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { BsDatepickerViewState } from 'src/datepicker/reducer/bs-datepicker.state';
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'demo-datepicker-view-change-event',
+  templateUrl: './view-change-event.html'
+})
+export class DemoDatepickerViewChangeEventComponent {
+  view?: BsDatepickerViewState;
+
+  onViewChange(view: BsDatepickerViewState): void {
+    this.view = view;
+  }
+}

--- a/src/datepicker/base/bs-datepicker-container.ts
+++ b/src/datepicker/base/bs-datepicker-container.ts
@@ -16,6 +16,8 @@ import {
   WeekViewModel,
   YearsCalendarViewModel
 } from '../models';
+import { EventEmitter } from '@angular/core';
+import { BsDatepickerViewState } from '../reducer/bs-datepicker.state';
 
 export abstract class BsDatepickerAbstractComponent {
   containerClass = '';
@@ -36,6 +38,8 @@ export abstract class BsDatepickerAbstractComponent {
 
   isRangePicker?: boolean;
   withTimepicker?: boolean;
+
+  viewChange: EventEmitter<BsDatepickerViewState> = new EventEmitter<BsDatepickerViewState>();
 
   set minDate(value: Date|undefined) {
     this._effects?.setMinDate(value);

--- a/src/datepicker/bs-datepicker-inline.component.ts
+++ b/src/datepicker/bs-datepicker-inline.component.ts
@@ -23,6 +23,7 @@ import { DatepickerDateCustomClasses, DatepickerDateTooltipText } from './models
 import { BsDatepickerInlineContainerComponent } from './themes/bs/bs-datepicker-inline-container.component';
 import { copyTime } from './utils/copy-time-utils';
 import { checkBsValue, setCurrentTimeOnDateSelect } from './utils/bs-calendar-utils';
+import { BsDatepickerViewState } from './reducer/bs-datepicker.state';
 
 @Directive({
   selector: 'bs-datepicker-inline',
@@ -62,6 +63,10 @@ export class BsDatepickerInlineDirective implements OnInit, OnDestroy, OnChanges
    */
   @Input() datesDisabled?: Date[];
   /**
+   * Emits when datepicker view has been changed
+   */
+  @Output() bsViewChange: EventEmitter<BsDatepickerViewState> = new EventEmitter();
+  /**
    * Emits when datepicker value has been changed
    */
   @Output() bsValueChange: EventEmitter<Date> = new EventEmitter();
@@ -96,14 +101,14 @@ export class BsDatepickerInlineDirective implements OnInit, OnDestroy, OnChanges
       return;
     }
 
-     if (!this._bsValue && value && !this._config.withTimepicker) {
-       const now = new Date();
-       copyTime(value, now);
-     }
+    if (!this._bsValue && value && !this._config.withTimepicker) {
+      const now = new Date();
+      copyTime(value, now);
+    }
 
     if (value && this.bsConfig?.initCurrentTime) {
       value = setCurrentTimeOnDateSelect(value);
-     }
+    }
 
     this._bsValue = value;
     this.bsValueChange.emit(value);
@@ -128,6 +133,11 @@ export class BsDatepickerInlineDirective implements OnInit, OnDestroy, OnChanges
       this._subs.push(
         this._datepickerRef.instance.valueChange.subscribe((value: Date) => {
           this.bsValue = value;
+        })
+      );
+      this._subs.push(
+        this._datepickerRef.instance.viewChange.subscribe((view: BsDatepickerViewState) => {
+          this.bsViewChange.emit(view);
         })
       );
     }

--- a/src/datepicker/bs-datepicker.component.ts
+++ b/src/datepicker/bs-datepicker.component.ts
@@ -21,6 +21,7 @@ import { BsDatepickerViewMode, DatepickerDateCustomClasses, DatepickerDateToolti
 import { BsDatepickerContainerComponent } from './themes/bs/bs-datepicker-container.component';
 import { copyTime } from './utils/copy-time-utils';
 import { checkBsValue, setCurrentTimeOnDateSelect } from './utils/bs-calendar-utils';
+import { BsDatepickerViewState } from './reducer/bs-datepicker.state';
 
 @Directive({
   selector: '[bsDatepicker]',
@@ -93,6 +94,10 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges, Afte
    */
   @Input() dateTooltipTexts?: DatepickerDateTooltipText[];
   /**
+   * Emits when datepicker view has been changed
+   */
+  @Output() bsViewChange: EventEmitter<BsDatepickerViewState> = new EventEmitter();
+  /**
    * Emits when datepicker value has been changed
    */
   @Output() bsValueChange: EventEmitter<Date> = new EventEmitter();
@@ -102,10 +107,10 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges, Afte
   private readonly _dateInputFormat$ = new Subject<string | undefined>();
 
   constructor(public _config: BsDatepickerConfig,
-              private  _elementRef: ElementRef,
-              private  _renderer: Renderer2,
-              _viewContainerRef: ViewContainerRef,
-              cis: ComponentLoaderFactory) {
+    private _elementRef: ElementRef,
+    private _renderer: Renderer2,
+    _viewContainerRef: ViewContainerRef,
+    cis: ComponentLoaderFactory) {
     // todo: assign only subset of fields
     Object.assign(this, this._config);
     this._datepicker = cis.createLoader<BsDatepickerContainerComponent>(
@@ -240,6 +245,11 @@ export class BsDatepickerDirective implements OnInit, OnDestroy, OnChanges, Afte
         this._datepickerRef.instance.valueChange.subscribe((value: Date) => {
           this.bsValue = value;
           this.hide();
+        })
+      );
+      this._subs.push(
+        this._datepickerRef.instance.viewChange.subscribe((view: BsDatepickerViewState) => {
+          this.bsViewChange.emit(view);
         })
       );
     }

--- a/src/datepicker/bs-daterangepicker-inline.component.ts
+++ b/src/datepicker/bs-daterangepicker-inline.component.ts
@@ -17,6 +17,7 @@ import {
   checkRangesWithMaxDate,
   setDateRangesCurrentTimeOnDateSelect
 } from './utils/bs-calendar-utils';
+import { BsDatepickerViewState } from './reducer/bs-datepicker.state';
 
 @Directive({
     selector: 'bs-daterangepicker-inline',
@@ -73,6 +74,10 @@ export class BsDaterangepickerInlineDirective implements OnInit, OnDestroy, OnCh
      * Disable specific dates
      */
     @Input() datesEnabled?: Date[];
+    /**
+     * Emits when datepicker view has been changed
+     */
+    @Output() bsViewChange: EventEmitter<BsDatepickerViewState> = new EventEmitter();
     /**
      * Emits when daterangepicker value has been changed
      */
@@ -200,6 +205,11 @@ export class BsDaterangepickerInlineDirective implements OnInit, OnDestroy, OnCh
           .subscribe((value: Date[]) => {
             this.bsValue = value;
           })
+      );
+      this._subs.push(
+        this._datepickerRef.instance.viewChange.subscribe((view: BsDatepickerViewState) => {
+          this.bsViewChange.emit(view);
+        })
       );
     }
   }

--- a/src/datepicker/bs-daterangepicker.component.ts
+++ b/src/datepicker/bs-daterangepicker.component.ts
@@ -1,4 +1,5 @@
-import { AfterViewInit, ComponentRef,
+import {
+  AfterViewInit, ComponentRef,
   Directive, ElementRef, EventEmitter,
   Input, OnChanges, OnDestroy, OnInit,
   Output, Renderer2, SimpleChanges,
@@ -16,6 +17,7 @@ import {
   checkRangesWithMaxDate,
   setDateRangesCurrentTimeOnDateSelect
 } from './utils/bs-calendar-utils';
+import { BsDatepickerViewState } from './reducer/bs-datepicker.state';
 
 @Directive({
   selector: '[bsDaterangepicker]',
@@ -64,7 +66,7 @@ export class BsDaterangepickerDirective
    */
   @Output() onHidden: EventEmitter<unknown>;
 
-  _bsValue?: (Date|undefined)[];
+  _bsValue?: (Date | undefined)[];
   isOpen$: BehaviorSubject<boolean>;
   isDestroy$ = new Subject();
 
@@ -72,7 +74,7 @@ export class BsDaterangepickerDirective
    * Initial value of daterangepicker
    */
   @Input()
-  set bsValue(value: (Date|undefined)[] | undefined) {
+  set bsValue(value: (Date | undefined)[] | undefined) {
     if (this._bsValue === value) {
       return;
     }
@@ -119,9 +121,13 @@ export class BsDaterangepickerDirective
    */
   @Input() datesEnabled?: Date[];
   /**
+  * Emits when datepicker view has been changed
+  */
+  @Output() bsViewChange: EventEmitter<BsDatepickerViewState> = new EventEmitter();
+  /**
    * Emits when daterangepicker value has been changed
    */
-  @Output() bsValueChange = new EventEmitter<((Date|undefined)[]|undefined)>();
+  @Output() bsValueChange = new EventEmitter<((Date | undefined)[] | undefined)>();
 
   get rangeInputFormat$(): Observable<string> {
     return this._rangeInputFormat$;
@@ -133,10 +139,10 @@ export class BsDaterangepickerDirective
   private readonly _rangeInputFormat$ = new Subject<string>();
 
   constructor(public _config: BsDaterangepickerConfig,
-              private  _elementRef: ElementRef,
-              private  _renderer: Renderer2,
-              _viewContainerRef: ViewContainerRef,
-              cis: ComponentLoaderFactory) {
+    private _elementRef: ElementRef,
+    private _renderer: Renderer2,
+    _viewContainerRef: ViewContainerRef,
+    cis: ComponentLoaderFactory) {
     this._datepicker = cis.createLoader<BsDaterangepickerContainerComponent>(
       _elementRef,
       _viewContainerRef,
@@ -250,6 +256,11 @@ export class BsDaterangepickerDirective
             this.bsValue = value;
             this.hide();
           })
+      );
+      this._subs.push(
+        this._datepickerRef.instance.viewChange.subscribe((view: BsDatepickerViewState) => {
+          this.bsViewChange.emit(view);
+        })
       );
     }
   }

--- a/src/datepicker/themes/bs/bs-datepicker-container.component.ts
+++ b/src/datepicker/themes/bs/bs-datepicker-container.component.ts
@@ -23,6 +23,7 @@ import { CalendarCellViewModel, DayViewModel } from '../../models';
 import { BsDatepickerActions } from '../../reducer/bs-datepicker.actions';
 import { BsDatepickerEffects } from '../../reducer/bs-datepicker.effects';
 import { BsDatepickerStore } from '../../reducer/bs-datepicker.store';
+import { BsDatepickerState } from '../../reducer/bs-datepicker.state';
 
 @Component({
   selector: 'bs-datepicker-container',
@@ -39,7 +40,7 @@ import { BsDatepickerStore } from '../../reducer/bs-datepicker.store';
 export class BsDatepickerContainerComponent extends BsDatepickerAbstractComponent
   implements OnInit, AfterViewInit, OnDestroy {
 
-  set value(value: Date|undefined) {
+  set value(value: Date | undefined) {
     this._effects?.setValue(value);
   }
 
@@ -115,9 +116,11 @@ export class BsDatepickerContainerComponent extends BsDatepickerAbstractComponen
     // todo: move it somewhere else
     // on selected date change
     this._subs.push(
-      this._store.select((state: any) => state.selectedDate).subscribe((date: any) => this.valueChange.emit(date))
+      this._store.select((state: BsDatepickerState) => state.selectedDate).subscribe((date: any) => this.valueChange.emit(date))
     );
-
+    this._subs.push(
+      this._store.select((state: BsDatepickerState) => state.view).subscribe((view) => this.viewChange.emit(view))
+    );
 
     this._store.dispatch(this._actions.changeViewMode(this._config.startView));
   }
@@ -147,7 +150,7 @@ export class BsDatepickerContainerComponent extends BsDatepickerAbstractComponen
 
   override daySelectHandler(day: DayViewModel): void {
     if (!day) {
-     return;
+      return;
     }
 
     const isDisabled = this.isOtherMonthsActive ? day.isDisabled : (day.isOtherMonth || day.isDisabled);

--- a/src/datepicker/themes/bs/bs-daterangepicker-container.component.ts
+++ b/src/datepicker/themes/bs/bs-daterangepicker-container.component.ts
@@ -41,7 +41,7 @@ import { dayInMilliseconds } from '../../reducer/_defaults';
 export class BsDaterangepickerContainerComponent extends BsDatepickerAbstractComponent
   implements OnInit, OnDestroy, AfterViewInit {
 
-  set value(value: (Date|undefined)[] | undefined) {
+  set value(value: (Date | undefined)[] | undefined) {
     this._effects?.setRangeValue(value);
   }
 
@@ -122,6 +122,11 @@ export class BsDaterangepickerContainerComponent extends BsDatepickerAbstractCom
           this.valueChange.emit(dateRange);
           this.chosenRange = dateRange || [];
         })
+    );
+    this._subs.push(
+      this._store
+        .select(state => state.view)
+        .subscribe(view => this.viewChange.emit(view))
     );
   }
 
@@ -226,7 +231,7 @@ export class BsDaterangepickerContainerComponent extends BsDatepickerAbstractCom
       this._rangeStack =
         day.date >= this._rangeStack[0]
           ? [this._rangeStack[0], day.date]
-          :  [day.date];
+          : [day.date];
     }
 
     if (this._config.maxDateRange) {
@@ -268,7 +273,7 @@ export class BsDaterangepickerContainerComponent extends BsDatepickerAbstractCom
 
     if (this._config.maxDate) {
       const maxDateValueInMilliseconds = this._config.maxDate.getTime();
-      const maxDateRangeInMilliseconds = currentSelection.getTime() + ((this._config.maxDateRange || 0) * dayInMilliseconds );
+      const maxDateRangeInMilliseconds = currentSelection.getTime() + ((this._config.maxDateRange || 0) * dayInMilliseconds);
       maxDateRange = maxDateRangeInMilliseconds > maxDateValueInMilliseconds ?
         new Date(this._config.maxDate) :
         new Date(maxDateRangeInMilliseconds);


### PR DESCRIPTION
Navigating through the datepicker calendar will emit a bsViewChange event.

Closes #1153

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [✔] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [✔] built and tested the changes locally.
 - [✔] added/updated tests.
 - [✔] added/updated API documentation.
 - [✔] added/updated demos.
