### PR TITLE
fix: add bs-datepicker.css file to package.json exports

### DIFF
--- a/src/root/package.json
+++ b/src/root/package.json
@@ -80,6 +80,9 @@
       "node": "./datepicker/fesm2015/ngx-bootstrap-datepicker.mjs",
       "default": "./datepicker/fesm2020/ngx-bootstrap-datepicker.mjs"
     },
+    "./datepicker/bs-datepicker.css": {
+      "style": "./datepicker/bs-datepicker.css"
+    },
     "./dropdown": {
       "types": "./dropdown/ngx-bootstrap-dropdown.d.ts",
       "esm2020": "./dropdown/esm2020/ngx-bootstrap-dropdown.mjs",


### PR DESCRIPTION
This PR enables importing "bs-datepicker.css" file when using Yarn with PnP. When declared, the "exports" field in a package.json is meant to conceal and exclude all unspecified files or directories. Until now the exclusion of "bs-datepicker.css" wasn't an apparent issue because no other package manager/strategy is able to enforce disallowing importing files not specified in the "exports" field but Yarn with PnP enforces it.

https://nodejs.org/api/packages.html#packages_exports
https://github.com/jkrems/proposal-pkg-exports/
https://angular.io/guide/creating-libraries#managing-assets-in-a-library

fixes #6449
