### PR TITLE
fix(carousel): add client side check before calling window to prevent reference error in angular ssr

### DIFF
--- a/src/carousel/carousel.component.ts
+++ b/src/carousel/carousel.component.ts
@@ -149,7 +149,7 @@ export class CarouselComponent implements AfterViewInit, OnDestroy {
     return getBsVer();
   }
 
-  constructor(config: CarouselConfig, private ngZone: NgZone, @Inject(PLATFORM_ID) public platformId: Object) {
+  constructor(config: CarouselConfig, private ngZone: NgZone, @Inject(PLATFORM_ID) public platformId: number) {
     Object.assign(this, config);
     this.currentId = _currentId++;
   }

--- a/src/carousel/carousel.component.ts
+++ b/src/carousel/carousel.component.ts
@@ -16,8 +16,9 @@
  */
 
 import {
-  Component, EventEmitter, Input, NgZone, OnDestroy, Output, AfterViewInit
+  Component, EventEmitter, Input, NgZone, OnDestroy, Output, AfterViewInit, Inject, PLATFORM_ID
 } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 
 import { isBs3, LinkedList, getBsVer, IBsVersion } from 'ngx-bootstrap/utils';
 import { SlideComponent } from './slide.component';
@@ -148,7 +149,7 @@ export class CarouselComponent implements AfterViewInit, OnDestroy {
     return getBsVer();
   }
 
-  constructor(config: CarouselConfig, private ngZone: NgZone) {
+  constructor(config: CarouselConfig, private ngZone: NgZone, @Inject(PLATFORM_ID) public platformId: Object) {
     Object.assign(this, config);
     this.currentId = _currentId++;
   }
@@ -790,7 +791,7 @@ export class CarouselComponent implements AfterViewInit, OnDestroy {
   private restartTimer() {
     this.resetTimer();
     const interval = +this.interval;
-    if (!isNaN(interval) && interval > 0) {
+    if (!isNaN(interval) && interval > 0 && isPlatformBrowser(this.platformId)) {
       this.currentInterval = this.ngZone.runOutsideAngular<number>(() => {
         return window.setInterval(() => {
           const nInterval = +this.interval;


### PR DESCRIPTION
[Carousel] - With Angular SSR, we need to check if we are on the client side before calling the window object to avoid a "window is not defined" reference error on server side.
This fix does not affect existing tests, docs or demos.

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [X] built and tested the changes locally.
 - [] added/updated tests.
 - [] added/updated API documentation.
 - [] added/updated demos.
