### PR TITLE
fix(modal): hide works even if show hasn't finished

### DIFF
--- a/src/modal/bs-modal.service.ts
+++ b/src/modal/bs-modal.service.ts
@@ -134,7 +134,7 @@ export class BsModalService {
       .provide({ provide: BsModalRef, useValue: bsModalRef })
       .attach(ModalContainerComponent)
       .to('body');
-    bsModalRef.hide = () => modalContainerRef.instance?.hide();
+    bsModalRef.hide = () => this.hide(bsModalRef.id);
     bsModalRef.setClass = (newClass: string) => {
       if (modalContainerRef.instance) {
         modalContainerRef.instance.config.class = newClass;

--- a/src/modal/modal-container.component.ts
+++ b/src/modal/modal-container.component.ts
@@ -135,7 +135,7 @@ export class ModalContainerComponent implements OnInit, OnDestroy {
   }
 
   hide(): void {
-    if (this.isModalHiding || !this.isShown) {
+    if (this.isModalHiding) {
       return;
     }
 

--- a/src/modal/testing/modal.service.spec.ts
+++ b/src/modal/testing/modal.service.spec.ts
@@ -7,17 +7,17 @@ import { BsModalService, ModalModule } from '../index';
 @Component({ template: '<div>Dummy Component</div>' })
 class DummyComponent {
   // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
-    constructor(modalService: BsModalService) { }
+  constructor(modalService: BsModalService) { }
 }
 
 @Component({
-    template: '<div>Test Component</div>'
+  template: '<div>Test Component</div>'
 })
-class TestModalComponent { }
+export class TestModalComponent { }
 
 @NgModule({
-    declarations: [TestModalComponent],
-    entryComponents: [TestModalComponent]
+  declarations: [TestModalComponent],
+  entryComponents: [TestModalComponent]
 })
 export class TestModule { }
 
@@ -37,21 +37,19 @@ describe('Modal service', () => {
     fixture.detectChanges();
   });
 
-  it('should return random id on spin up a new modal', done => {
+  it('should return random id on spin up a new modal', () => {
     modalService.onShown.subscribe((data) => {
       expect(data.id).toBeTruthy();
-      done();
     });
 
     modalService.show(TestModalComponent);
   });
 
-  it('should return different random id when open nested modal without specifying id', done => {
+  it('should return different random id when open nested modal without specifying id', () => {
     modalService.onShown.pipe(
       pairwise(),
       tap(([firstData, secondData]) => {
         expect(firstData.id).not.toBe(secondData.id);
-        done();
       })
     ).subscribe();
 
@@ -59,12 +57,11 @@ describe('Modal service', () => {
     modalService.show(TestModalComponent);
   });
 
-  it('should return id in config when specified', done => {
+  it('should return id in config when specified', () => {
     const id = 20;
 
     modalService.onShown.subscribe((data) => {
       expect(data.id).toBe(id);
-      done();
     });
 
     modalService.show(TestModalComponent, { id });
@@ -72,6 +69,7 @@ describe('Modal service', () => {
 
   it('should return id when hide modal', () => {
     const id = 20;
+    jest.useFakeTimers();
 
     modalService.onHidden.subscribe((data) => {
       expect(data.id).toBe(id);
@@ -79,5 +77,29 @@ describe('Modal service', () => {
 
     const bsRef = modalService.show(TestModalComponent, { id });
     bsRef.hide();
+
+    jest.runAllTimers();
+  });
+
+  it('should hide modal even if invoked right after show', () => {
+    const id = 25;
+    const onHideSpy = jest.spyOn(modalService.onHide, 'emit');
+    const onHiddenSpy = jest.spyOn(modalService.onHidden, 'emit');
+    jest.useFakeTimers();
+
+    modalService.onHidden.subscribe((data) => {
+      expect(data.id).toBe(id);
+    });
+
+    modalService.onHide.subscribe((data) => {
+      expect(data.id).toBe(id);
+    });
+
+    const bsRef = modalService.show(TestModalComponent, { id });
+    bsRef.hide();
+
+    jest.runAllTimers();
+    expect(onHideSpy).toHaveBeenCalled();
+    expect(onHiddenSpy).toHaveBeenCalledWith({ id });
   });
 });

--- a/src/modal/testing/modal.service.spec.ts
+++ b/src/modal/testing/modal.service.spec.ts
@@ -37,19 +37,21 @@ describe('Modal service', () => {
     fixture.detectChanges();
   });
 
-  it('should return random id on spin up a new modal', () => {
+  it('should return random id on spin up a new modal', done => {
     modalService.onShown.subscribe((data) => {
       expect(data.id).toBeTruthy();
+      done();
     });
 
     modalService.show(TestModalComponent);
   });
 
-  it('should return different random id when open nested modal without specifying id', () => {
+  it('should return different random id when open nested modal without specifying id', done => {
     modalService.onShown.pipe(
       pairwise(),
       tap(([firstData, secondData]) => {
         expect(firstData.id).not.toBe(secondData.id);
+        done();
       })
     ).subscribe();
 
@@ -57,22 +59,24 @@ describe('Modal service', () => {
     modalService.show(TestModalComponent);
   });
 
-  it('should return id in config when specified', () => {
+  it('should return id in config when specified', done => {
     const id = 20;
 
     modalService.onShown.subscribe((data) => {
       expect(data.id).toBe(id);
+      done();
     });
 
     modalService.show(TestModalComponent, { id });
   });
 
-  it('should return id when hide modal', () => {
+  it('should return id when hide modal', done => {
     const id = 20;
     jest.useFakeTimers();
 
     modalService.onHidden.subscribe((data) => {
       expect(data.id).toBe(id);
+      done();
     });
 
     const bsRef = modalService.show(TestModalComponent, { id });
@@ -83,16 +87,24 @@ describe('Modal service', () => {
 
   it('should hide modal even if invoked right after show', () => {
     const id = 25;
-    const onHideSpy = jest.spyOn(modalService.onHide, 'emit');
-    const onHiddenSpy = jest.spyOn(modalService.onHidden, 'emit');
     jest.useFakeTimers();
 
-    modalService.onHidden.subscribe((data) => {
-      expect(data.id).toBe(id);
-    });
+    const bsRef = modalService.show(TestModalComponent, { id });
+    expect(modalService.getModalsCount()).toBe(1);
+    bsRef.hide();
+
+    jest.runAllTimers();
+    expect(modalService.getModalsCount()).toBe(0);
+  });
+
+  it('should emit onHide after hide is invoked', done => {
+    const id = 25;
+    const onHideSpy = jest.spyOn(modalService.onHide, 'emit');
+    jest.useFakeTimers();
 
     modalService.onHide.subscribe((data) => {
       expect(data.id).toBe(id);
+      done();
     });
 
     const bsRef = modalService.show(TestModalComponent, { id });
@@ -100,6 +112,22 @@ describe('Modal service', () => {
 
     jest.runAllTimers();
     expect(onHideSpy).toHaveBeenCalled();
+  });
+
+  it('should emit (id) onHidden after hide is invoked', done => {
+    const id = 25;
+    const onHiddenSpy = jest.spyOn(modalService.onHidden, 'emit');
+    jest.useFakeTimers();
+
+    modalService.onHidden.subscribe((data) => {
+      expect(data.id).toBe(id);
+      done();
+    });
+
+    const bsRef = modalService.show(TestModalComponent, { id });
+    bsRef.hide();
+
+    jest.runAllTimers();
     expect(onHiddenSpy).toHaveBeenCalledWith({ id });
   });
 });


### PR DESCRIPTION
This PR fix the problem we face when calling `hide()` on a modal reference before the modal animation has finished, in which case `hide()` has no effect into the displayed modal, staying open.

This change will enable us to call `show()` and right after `hide()` - and it will work as expected. Unit test is added.

The current workaround is adding `setTimeout` to call `hide()` in those cases that we might want to hide before loading the modal content is finished (cache data, quick api response, e2e tests...). This may impact the codebase and e2e tests, adding unnecessary timeouts and async awaits.

There is also another way of hiding the modal in those short-time shows, which is calling the `hide` method from the service passing the modal reference id, but still feels like the hide method from the modal reference should act the same way. These two ways and the issue are shown in the demo link below:

Issue demo: https://stackblitz.com/edit/ngx-bootstrap-modal-show-hide-issue-demo

before:
```
const ref = this.modalService.show(MyModalComponent);
// ref.hide(); // it wont work...
setTimeout(() => ref.hide(), TRANSITION_DURATIONS.MODAL);
```

after:
```
const ref = this.modalService.show(MyModalComponent);
ref.hide(); // it works!
```

Fixes https://github.com/valor-software/ngx-bootstrap/issues/6439 https://github.com/valor-software/ngx-bootstrap/issues/6195 https://github.com/valor-software/ngx-bootstrap/issues/5840 https://github.com/valor-software/ngx-bootstrap/issues/4270
______
_I took the liberty of improving/fixing the modal.service.spec. It seems that the done callbacks are not needed. Last test was not working, it was not entering the subscribe callback, so not executing the expect, making the test pass without validating the test case._

# PR Checklist

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [X] built and tested the changes locally.
 - [X] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
