### PR TITLE
feat(datepicker): add apply and cancel buttons

### DIFF
--- a/apps/ngx-bootstrap-docs/src/ng-api-doc.ts
+++ b/apps/ngx-bootstrap-docs/src/ng-api-doc.ts
@@ -712,13 +712,14 @@ export const ngdoc: any = {
         name: 'showApplyButton',
         defaultValue: 'false',
         type: 'boolean',
-        description: '<p>Shows apply and cancel button. Selected date is not sent from view to model until the user selects apply. The picker will remain open until the selection is applied, cancelled, or the picker is dismissed.</p>\n'
+        description:
+          '<p>Shows &#39;apply&#39; and &#39;cancel&#39; button, date is not sent from view to model until user presses apply. Picker remains opened until applied, cancelled or dismissed (clicked off of)</p>\n'
       },
       {
         name: 'showCancelButton',
         defaultValue: 'true',
         type: 'boolean',
-        description: '<p>Shows or hides the cancel button. This only applies if showApplyButton is true.</p>\n'
+        description: '<p>Shows &#39;cancel&#39; button (only if showApplyButton is also true)</p>\n'
       },
       {
         name: 'showClearButton',

--- a/apps/ngx-bootstrap-docs/src/ng-api-doc.ts
+++ b/apps/ngx-bootstrap-docs/src/ng-api-doc.ts
@@ -547,6 +547,24 @@ export const ngdoc: any = {
         description: '<p>Set allowed positions of container.</p>\n'
       },
       {
+        name: 'applyButtonLabel',
+        defaultValue: 'Apply',
+        type: 'string',
+        description: '<p>Label for &#39;apply&#39; button</p>\n'
+      },
+      {
+        name: 'applyPosition',
+        defaultValue: 'right',
+        type: 'string',
+        description: '<p>Positioning of &#39;apply&#39; buttons</p>\n'
+      },
+      {
+        name: 'cancelButtonLabel',
+        defaultValue: 'Cancel',
+        type: 'string',
+        description: '<p>Label for &#39;cancel&#39; button</p>\n'
+      },
+      {
         name: 'clearButtonLabel',
         defaultValue: 'Clear',
         type: 'string',
@@ -689,6 +707,18 @@ export const ngdoc: any = {
         type: 'boolean',
         description:
           '<p>Allows select daterange as first and last day of week by click on week number (dateRangePicker only)</p>\n'
+      },
+      {
+        name: 'showApplyButton',
+        defaultValue: 'false',
+        type: 'boolean',
+        description: '<p>Shows apply and cancel button. Selected date is not sent from view to model until the user selects apply. The picker will remain open until the selection is applied, cancelled, or the picker is dismissed.</p>\n'
+      },
+      {
+        name: 'showCancelButton',
+        defaultValue: 'true',
+        type: 'boolean',
+        description: '<p>Shows or hides the cancel button. This only applies if showApplyButton is true.</p>\n'
       },
       {
         name: 'showClearButton',

--- a/libs/doc-pages/datepicker/src/lib/datepicker-section.list.ts
+++ b/libs/doc-pages/datepicker/src/lib/datepicker-section.list.ts
@@ -48,11 +48,13 @@ import { DemoDateRangePickerMaxDateRangeComponent } from './demos/max-date-range
 import { DemoDateRangePickerDisplayOneMonth } from './demos/daterangepicker-display-one-month/display-one-month';
 import { DemoDatepickerTodayButtonComponent } from './demos/today-button/today-button';
 import { DemoDatepickerClearButtonComponent } from './demos/clear-button/clear-button';
+import { DemoDatepickerApplyButtonComponent } from './demos/apply-button/apply-button';
 import { DemoDatepickerStartViewComponent } from "./demos/start-view/start-view";
 import { DemoDatepickerPreventChangeToNextMonthComponent } from './demos/prevent-change-to-next-month/prevent-change-to-next-month.component';
 import { DemoDatepickerWithTimepickerComponent } from './demos/with-timepicker/with-timepicker';
 import { DatepickerCloseBehaviorComponent } from './demos/closeBehaviour/datepicker-close-behavior';
 import { KeepDatesOutOfRulesComponent } from './demos/keep-dates-out-of-rules/keep-dates-out-of-rules.component';
+
 
 export const demoComponentContent: ContentSection[] = [
   {
@@ -439,6 +441,14 @@ export const demoComponentContent: ContentSection[] = [
         outlet: DemoDatepickerClearButtonComponent
       },
       {
+        title: 'Show Apply Button',
+        anchor: 'datepicker-show-apply-button',
+        component: require('!!raw-loader!./demos/apply-button/apply-button.ts'),
+        html: require('!!raw-loader!./demos/apply-button/apply-button.html'),
+        description: `<p>Display an 'Apply' and 'Cancel' button. The datepicker will not update the model unless the 'Apply' button is pressed. If the 'Cancel' button is pressed the model value will not be updated and the datepicker will be closed. The datepicker will remain open until it is applied, cancelled, or dismissed.</p>`,
+        outlet: DemoDatepickerApplyButtonComponent
+      },
+      {
         title: 'Start view',
         anchor: 'start-view',
         component: require('!!raw-loader!./demos/start-view/start-view.ts'),
@@ -711,6 +721,11 @@ export const demoComponentContent: ContentSection[] = [
         title: 'Show Clear Button',
         anchor: 'datepicker-show-clear-button-ex',
         outlet: DemoDatepickerClearButtonComponent
+      },
+      {
+        title: 'Show Apply Button',
+        anchor: 'datepicker-show-apply-button-ex',
+        outlet: DemoDatepickerApplyButtonComponent
       },
       {
         title: 'Start view',

--- a/libs/doc-pages/datepicker/src/lib/demos/apply-button/apply-button.html
+++ b/libs/doc-pages/datepicker/src/lib/demos/apply-button/apply-button.html
@@ -1,0 +1,9 @@
+<div class="row">
+    <div class="col-xs-12 col-12 col-md-4 form-group mb-3">
+      <input type="text"
+             placeholder="Datepicker"
+             class="form-control"
+             bsDatepicker
+             [bsConfig]="{ containerClass: 'theme-dark-blue', showApplyButton: true, showCancelButton: true }">
+    </div>
+  </div>

--- a/libs/doc-pages/datepicker/src/lib/demos/apply-button/apply-button.ts
+++ b/libs/doc-pages/datepicker/src/lib/demos/apply-button/apply-button.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'demo-datepicker-apply-button',
+  templateUrl: './apply-button.html'
+})
+export class DemoDatepickerApplyButtonComponent {}

--- a/libs/doc-pages/datepicker/src/lib/demos/index.ts
+++ b/libs/doc-pages/datepicker/src/lib/demos/index.ts
@@ -40,11 +40,13 @@ import { DemoDateRangePickerMaxDateRangeComponent } from './max-date-range/max-d
 import { DemoDateRangePickerDisplayOneMonth } from './daterangepicker-display-one-month/display-one-month';
 import { DemoDatepickerTodayButtonComponent } from './today-button/today-button';
 import { DemoDatepickerClearButtonComponent } from './clear-button/clear-button';
+import { DemoDatepickerApplyButtonComponent } from './apply-button/apply-button';
 import { DemoDatepickerStartViewComponent } from "./start-view/start-view";
 import { DemoDatepickerPreventChangeToNextMonthComponent } from './prevent-change-to-next-month/prevent-change-to-next-month.component';
 import { DemoDatepickerWithTimepickerComponent } from './with-timepicker/with-timepicker';
 import { DatepickerCloseBehaviorComponent } from './closeBehaviour/datepicker-close-behavior';
 import { KeepDatesOutOfRulesComponent } from './keep-dates-out-of-rules/keep-dates-out-of-rules.component';
+
 
 export const DEMO_COMPONENTS = [
   DemoDatePickerAdaptivePositionComponent,
@@ -84,6 +86,7 @@ export const DEMO_COMPONENTS = [
   DemoDatePickerVisibilityEventsComponent,
   DemoDatepickerTodayButtonComponent,
   DemoDatepickerClearButtonComponent,
+  DemoDatepickerApplyButtonComponent,
   DemoDateRangePickerShowPreviousMonth,
   DemoDateRangePickerMaxDateRangeComponent,
   DemoDatepickerPreventChangeToNextMonthComponent,

--- a/src/datepicker/base/bs-datepicker-container.ts
+++ b/src/datepicker/base/bs-datepicker-container.ts
@@ -26,7 +26,12 @@ export abstract class BsDatepickerAbstractComponent {
   showClearBtn?: boolean;
   clearBtnLbl?: string;
   clearPos?: string;
-
+  showApplyBtn?: boolean;
+  showCancelBtn?: boolean;
+  cancelBtnLbl?: string;
+  applyBtnLbl?: string;
+  applyPos?: string;
+  
   _effects?: BsDatepickerEffects;
   customRanges: BsCustomDates[] = [];
   customRangeBtnLbl?: string;
@@ -129,6 +134,12 @@ export abstract class BsDatepickerAbstractComponent {
 
   // eslint-disable-next-line
   clearDate(): void {}
+
+  // eslint-disable-next-line
+  apply(): void {}
+
+  // eslint-disable-next-line
+  cancel(): void {}
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   _stopPropagation(event: any): void {

--- a/src/datepicker/bs-datepicker.config.ts
+++ b/src/datepicker/bs-datepicker.config.ts
@@ -24,44 +24,54 @@ export class BsDatepickerConfig implements DatepickerRenderOptions {
   isAnimated = false;
   value?: Date | Date[];
   isDisabled?: boolean;
+  
   /**
    * Default min date for all date/range pickers
    */
   minDate?: Date;
+
   /**
    * Default max date for all date/range pickers
    */
   maxDate?: Date;
+
   /**
    * The view that the datepicker should start in
    */
   startView: BsDatepickerViewMode = 'day';
+
   /**
    * Default date custom classes for all date/range pickers
    */
   dateCustomClasses?: DatepickerDateCustomClasses[];
+
   /**
    * Default tooltip text for all date/range pickers
    */
   dateTooltipTexts?: DatepickerDateTooltipText[];
+
   /**
    * Disable specific days, e.g. [0,6] will disable all Saturdays and Sundays
    */
   daysDisabled?: number[];
+
   /**
    * Disable specific dates
    */
   datesDisabled?: Date[];
+
   /**
    * Show one months for special cases (only for dateRangePicker)
    * 1. maxDate is equal to today's date
    * 2. minDate's month is equal to maxDate's month
    */
   displayOneMonthRange?: boolean;
+
   /**
    * Enable specific dates
    */
   datesEnabled?: Date[];
+
   /**
    * Makes dates from other months active
    */
@@ -109,14 +119,17 @@ export class BsDatepickerConfig implements DatepickerRenderOptions {
 
   // DatepickerRenderOptions
   displayMonths = 1;
+  
   /**
    * Allows to hide week numbers in datepicker
    */
   showWeekNumbers = true;
 
   dateInputFormat = 'L';
+
   // range picker
   rangeSeparator = ' - ';
+
   /**
    * Date format for date range input field
    */
@@ -151,6 +164,16 @@ export class BsDatepickerConfig implements DatepickerRenderOptions {
   showClearButton = false;
 
   /**
+   * Shows 'apply' and 'cancel' button, date is not sent from view to model until user presses apply. Picker remains opened until applied, cancelled or dismissed (clicked off of)
+   */
+  showApplyButton = false;
+
+  /**
+   * Shows 'cancel' button this is only if showApplyButton is also true
+   */
+  showCancelButton = true;
+
+  /**
    * Positioning of 'today' button
    */
   todayPosition = 'center';
@@ -159,6 +182,11 @@ export class BsDatepickerConfig implements DatepickerRenderOptions {
    * Positioning of 'clear' button
    */
   clearPosition = 'right';
+  
+  /**
+   * Positioning of 'apply' button
+   */
+  applyPosition = 'right';
 
   /**
    * Label for 'today' button
@@ -171,6 +199,16 @@ export class BsDatepickerConfig implements DatepickerRenderOptions {
   clearButtonLabel = 'Clear';
 
   /**
+   * Label for 'cancel' button
+   */
+  cancelButtonLabel = 'Cancel';
+
+  /**
+   * Label for 'apply' button
+   */
+  applyButtonLabel = 'Apply';
+
+  /**
    * Label for 'custom range' button
    */
   customRangeButtonLabel = 'Custom Range';
@@ -179,18 +217,22 @@ export class BsDatepickerConfig implements DatepickerRenderOptions {
    * Shows timepicker under datepicker
    */
   withTimepicker = false;
+
   /**
    * Set current hours, minutes, seconds and milliseconds for bsValue
    */
   initCurrentTime?: boolean;
+
   /**
    * Set allowed positions of container.
    */
   allowedPositions = ['top', 'bottom'];
+
   /**
    * Set rule for datepicker closing. If value is true datepicker closes only if date is changed, if user changes only time datepicker doesn't close. It is available only if property withTimepicker is set true
    * */
   keepDatepickerOpened = false;
+
   /**
    * Allows keep invalid dates in range. Can be used with minDate, maxDate
    * */

--- a/src/datepicker/bs-datepicker.scss
+++ b/src/datepicker/bs-datepicker.scss
@@ -427,6 +427,7 @@
 
   .bs-media-container {
     display: flex;
+    justify-content: center;
     @media(max-width: 768px) {
       flex-direction: column;
     }
@@ -470,28 +471,32 @@
     flex-flow: row wrap;
     justify-content: flex-end;
     padding-top: 10px;
-    border-top: 1px solid $border-color;
+    gap: 5px;
 
     .btn-default {
-      margin-left: 10px;
+      margin-right: 5px;
     }
 
-    .btn-today-wrapper {
+    .btn-today-wrapper,
+    .btn-apply-wrapper{
       display: flex;
       flex-flow: row wrap;
     }
 
     .clear-right,
-    .today-right {
+    .today-right,
+    .apply-right {
       flex-grow: 0;
     }
     .clear-left,
-    .today-left {
+    .today-left,
+    .apply-left {
       flex-grow: 1;
     }
 
     .clear-center,
-    .today-center {
+    .today-center,
+    .apply-center {
       flex-grow: 0.5;
     }
   }

--- a/src/datepicker/testing/bs-datepicker.spec.ts
+++ b/src/datepicker/testing/bs-datepicker.spec.ts
@@ -178,6 +178,72 @@ describe('datepicker:', () => {
     expect(buttonText.filter(button => button === clearBtnCustomLbl).length).toEqual(1);
   });
 
+
+  it('should show the apply button when showApplyButton config is true', fakeAsync(() => {
+    const datepickerDirective = getDatepickerDirective(fixture);
+    datepickerDirective.bsConfig = {
+      showApplyButton: true
+    };
+    showDatepicker(fixture);
+    tick();
+    fixture.whenStable().then(() => {
+      const buttonText: string[] = [];
+      Array.from(document.body.getElementsByTagName('button'))
+        .forEach(button => buttonText.push(button.textContent));
+      expect(buttonText.filter(button => button === 'Apply').length).toEqual(1);
+    });
+    expect(true).toBeTruthy();
+  }));
+
+  it('should hide the cancel button when showApplyButton config is true and showCancelbutton config is false', fakeAsync(() => {
+    const datepickerDirective = getDatepickerDirective(fixture);
+    datepickerDirective.bsConfig = {
+      showApplyButton: true,
+      showCancelButton: false
+    };
+    showDatepicker(fixture);
+    tick();
+    fixture.whenStable().then(() => {
+      const buttonText: string[] = [];
+      Array.from(document.body.getElementsByTagName('button'))
+        .forEach(button => buttonText.push(button.textContent));
+      expect(buttonText.filter(button => button === 'Cancel').length).toEqual(0);
+    });
+    expect(true).toBeTruthy();
+  }));
+
+  it('should show custom label for apply button if set in config', () => {
+    const applyBtnCustomLbl = 'Apply date';
+    const datepickerDirective = getDatepickerDirective(fixture);
+    datepickerDirective.bsConfig = {
+      applyButtonLabel: applyBtnCustomLbl,
+      showApplyButton: true
+    };
+    showDatepicker(fixture);
+
+    const buttonText: string[] = [];
+    // fixture.debugElement.queryAll(By.css('button'))
+    Array.from(document.body.getElementsByTagName('button'))
+      .forEach(button => buttonText.push(button.textContent));
+    expect(buttonText.filter(button => button === applyBtnCustomLbl).length).toEqual(1);
+  });
+
+  it('should show custom label for cancel button if set in config', () => {
+    const cancelBtnCustomLbl = 'Cancel selection';
+    const datepickerDirective = getDatepickerDirective(fixture);
+    datepickerDirective.bsConfig = {
+      cancelButtonLabel: cancelBtnCustomLbl,
+      showApplyButton: true,
+    };
+    showDatepicker(fixture);
+
+    const buttonText: string[] = [];
+    // fixture.debugElement.queryAll(By.css('button'))
+    Array.from(document.body.getElementsByTagName('button'))
+      .forEach(button => buttonText.push(button.textContent));
+    expect(buttonText.filter(button => button === cancelBtnCustomLbl).length).toEqual(1);
+  });
+
   describe('should start with', () => {
 
     const parameters = [
@@ -226,6 +292,33 @@ describe('datepicker:', () => {
         });
       });
     });
+  });
+
+  
+  it('should not emit date until applied', () => {
+
+    const datepickerDirective = getDatepickerDirective(fixture);
+    datepickerDirective.bsConfig = {
+      showApplyButton: true
+    };
+    const datepicker = showDatepicker(fixture);
+    const datepickerContainerInstance = getDatepickerContainer(datepicker);
+
+    let emitValue: Date;
+
+    const sub = datepicker.bsValueChange.subscribe(val => {
+      emitValue = val;
+    });
+
+    datepickerContainerInstance.setToday();
+    fixture.detectChanges();
+    expect(emitValue).toBe(undefined);
+
+    datepickerContainerInstance.apply();
+    fixture.detectChanges();
+    expect(emitValue).not.toBe(undefined);
+
+    sub.unsubscribe();
   });
 
   it('should set today date', () => {

--- a/src/datepicker/themes/bs/bs-datepicker-container.component.ts
+++ b/src/datepicker/themes/bs/bs-datepicker-container.component.ts
@@ -42,6 +42,8 @@ export class BsDatepickerContainerComponent
   implements OnInit, AfterViewInit, OnDestroy
 {
   valueChange: EventEmitter<Date> = new EventEmitter<Date>();
+  valueApplied: EventEmitter<any> = new EventEmitter();
+  valueCancelled: EventEmitter<any> = new EventEmitter();
   animationState = 'void';
   override isRangePicker = false;
   _subs: Subscription[] = [];
@@ -113,6 +115,11 @@ export class BsDatepickerContainerComponent
     this.showClearBtn = this._config.showClearButton;
     this.clearBtnLbl = this._config.clearButtonLabel;
     this.clearPos = this._config.clearPosition;
+    this.showApplyBtn = this._config.showApplyButton;
+    this.showCancelBtn = this._config.showCancelButton;
+    this.applyBtnLbl = this._config.applyButtonLabel;
+    this.applyPos = this._config.applyPosition;
+    this.cancelBtnLbl = this._config.cancelButtonLabel;
     this.customRangeBtnLbl = this._config.customRangeButtonLabel;
     this.withTimepicker = this._config.withTimepicker;
     this._effects
@@ -227,6 +234,14 @@ export class BsDatepickerContainerComponent
 
   override clearDate(): void {
     this._store.dispatch(this._actions.select(undefined));
+  }
+
+  override apply(): void {
+    this.valueApplied.emit();
+  }
+
+  override cancel(): void {
+    this.valueCancelled.emit();
   }
 
   ngOnDestroy(): void {

--- a/src/datepicker/themes/bs/bs-datepicker-container.component.ts
+++ b/src/datepicker/themes/bs/bs-datepicker-container.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 
 import { take } from 'rxjs/operators';
-import { Subscription } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 
 import { getFullYear, getMonth } from 'ngx-bootstrap/chronos';
 import { PositioningService } from 'ngx-bootstrap/positioning';
@@ -42,8 +42,8 @@ export class BsDatepickerContainerComponent
   implements OnInit, AfterViewInit, OnDestroy
 {
   valueChange: EventEmitter<Date> = new EventEmitter<Date>();
-  valueApplied: EventEmitter<any> = new EventEmitter();
-  valueCancelled: EventEmitter<any> = new EventEmitter();
+  valueApplied: Subject<void> = new Subject();
+  valueCancelled: Subject<void> = new Subject();
   animationState = 'void';
   override isRangePicker = false;
   _subs: Subscription[] = [];
@@ -237,11 +237,11 @@ export class BsDatepickerContainerComponent
   }
 
   override apply(): void {
-    this.valueApplied.emit();
+    this.valueApplied.next();
   }
 
   override cancel(): void {
-    this.valueCancelled.emit();
+    this.valueCancelled.next();
   }
 
   ngOnDestroy(): void {

--- a/src/datepicker/themes/bs/bs-datepicker-view.html
+++ b/src/datepicker/themes/bs/bs-datepicker-view.html
@@ -54,28 +54,32 @@
       </div>
     </div>
 
-    <!--applycancel buttons-->
-    <div class="bs-datepicker-buttons" *ngIf="false">
-      <button class="btn btn-success" type="button">Apply</button>
-      <button class="btn btn-default" type="button">Cancel</button>
-    </div>
 
-    <div class="bs-datepicker-buttons" *ngIf="showTodayBtn || showClearBtn">
+    <div class="bs-datepicker-buttons" *ngIf="showTodayBtn || showClearBtn || showApplyBtn">
       <div class="btn-today-wrapper"
-           [class.today-left]="todayPos === 'left'"
-           [class.today-right]="todayPos === 'right'"
-           [class.today-center]="todayPos === 'center'"
-           *ngIf="showTodayBtn">
+        [class.today-left]="todayPos === 'left'"
+        [class.today-right]="todayPos === 'right'"
+        [class.today-center]="todayPos === 'center'"
+        *ngIf="showTodayBtn">
         <button class="btn btn-success" (click)="setToday()">{{todayBtnLbl}}</button>
       </div>
 
-        <div class="btn-clear-wrapper"
+      <div class="btn-clear-wrapper"
         [class.clear-left]="clearPos === 'left'"
         [class.clear-right]="clearPos === 'right'"
         [class.clear-center]="clearPos === 'center'"
         *ngIf="showClearBtn">
-          <button class="btn btn-success" (click)="clearDate()">{{clearBtnLbl}}</button>
-        </div>
+        <button class="btn btn-success" (click)="clearDate()">{{clearBtnLbl}}</button>
+      </div>
+
+      <div class="btn-apply-wrapper"
+        [class.apply-left]="applyPos === 'left'"
+        [class.apply-right]="applyPos === 'right'"
+        [class.apply-center]="applyPos === 'center'"
+        *ngIf="showApplyBtn">
+        <button *ngIf="showCancelBtn" class="btn btn-default" (click)="cancel()">{{cancelBtnLbl}}</button>
+        <button class="btn btn-success" (click)="apply()">{{applyBtnLbl}}</button>
+      </div>
     </div>
 
   </div>

--- a/src/datepicker/utils/scss/mixins.scss
+++ b/src/datepicker/utils/scss/mixins.scss
@@ -6,7 +6,7 @@
       background-color: $color;
     }
 
-    .btn-today-wrapper, .btn-clear-wrapper {
+    .btn-today-wrapper, .btn-clear-wrapper, .btn-apply-wrapper {
       .btn-success {
         background-color: $color;
         border-color: $color;
@@ -22,7 +22,7 @@
     }
 
     @if $name == 'green' {
-      .btn-today-wrapper, .btn-clear-wrapper {
+      .btn-today-wrapper, .btn-clear-wrapper, .btn-apply-wrapper {
         .btn-success:not(:disabled):not(.disabled):active {
           background-color: $active-theme-green;
           border-color: $active-theme-green;
@@ -36,7 +36,7 @@
     }
 
     @if $name == 'blue' {
-      .btn-today-wrapper, .btn-clear-wrapper {
+      .btn-today-wrapper, .btn-clear-wrapper, .btn-apply-wrapper {
         .btn-success:not(:disabled):not(.disabled):active {
           background-color: $active-theme-blue;
           border-color: $active-theme-blue;
@@ -50,7 +50,7 @@
     }
 
     @if $name == 'dark-blue' {
-      .btn-today-wrapper, .btn-clear-wrapper {
+      .btn-today-wrapper, .btn-clear-wrapper, .btn-apply-wrapper {
         .btn-success:not(:disabled):not(.disabled):active {
           background-color: $active-theme-dark-blue;
           border-color: $active-theme-dark-blue;
@@ -64,7 +64,7 @@
     }
 
     @if $name == 'orange' {
-      .btn-today-wrapper, .btn-clear-wrapper {
+      .btn-today-wrapper, .btn-clear-wrapper, .btn-apply-wrapper {
         .btn-success:not(:disabled):not(.disabled):active {
           background-color: $active-theme-orange;
           border-color: $active-theme-orange;
@@ -78,7 +78,7 @@
     }
 
     @if $name == 'red' {
-      .btn-today-wrapper, .btn-clear-wrapper {
+      .btn-today-wrapper, .btn-clear-wrapper, .btn-apply-wrapper {
         .btn-success:not(:disabled):not(.disabled):active {
           background-color: $active-theme-red;
           border-color: $active-theme-red;
@@ -92,7 +92,7 @@
     }
 
     @if $name == 'default' {
-      .btn-today-wrapper, .btn-clear-wrapper {
+      .btn-today-wrapper, .btn-clear-wrapper, .btn-apply-wrapper {
         .btn-success:not(:disabled):not(.disabled):active {
           background-color: $active-theme-default;
           border-color: $active-theme-default;


### PR DESCRIPTION
# New feature description
This feature adds the option to enable an "Apply" and "Cancel" button to the datepicker. When enabled, the datepicker does not emit the change event from the view to the model until the value is applied by the new apply button. If the user chooses to cancel, the datepicker's value is reset back to the value of the model.

When this option is enabled it also keeps the datepicker open until the user applies, cancels, or dismisses the picker. This change improves the pickers behaviour when showTimePicker is also enabled as it allows the user to adjust both the date and time without the datepicker closing automatically after the date is updated. An issue discussed in #4203 .

The following new related config options have been added:

- showApplyButton
- showCancelButton
- applyButtonLabel
- cancelButtonLabel
- applyPosition

The css has also been slightly tweaked to improve appearance when all buttons are enabled. (Today, Clear, Apply and Cancel).

# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [X] built and tested the changes locally.
 - [X] added/updated tests.
 - [X] added/updated API documentation.
 - [X] added/updated demos.
