### PR TITLE
refactor(position)!: fix spelling mistake

### DIFF
--- a/src/positioning/utils/getBoundaries.ts
+++ b/src/positioning/utils/getBoundaries.ts
@@ -7,7 +7,7 @@ import { getFixedPositionOffsetParent } from './getFixedPositionOffsetParent';
 import { getOffsetRectRelativeToArbitraryNode } from './getOffsetRectRelativeToArbitraryNode';
 import { getParentNode } from './getParentNode';
 import { getScrollParent } from './getScrollParent';
-import { getViewportOffsetRectRelativeToArtbitraryNode } from './getViewportOffsetRectRelativeToArtbitraryNode';
+import { getViewportOffsetRectRelativeToArbitraryNode } from './getViewportOffsetRectRelativeToArbitraryNode';
 import { getWindowSizes } from './getWindowSizes';
 import { isFixed } from './isFixed';
 import { isNumber } from './isNumeric';
@@ -26,7 +26,7 @@ export function getBoundaries(
 
   // Handle viewport case
   if (boundariesElement === 'viewport') {
-    boundaries = getViewportOffsetRectRelativeToArtbitraryNode(offsetParent, fixedPosition);
+    boundaries = getViewportOffsetRectRelativeToArbitraryNode(offsetParent, fixedPosition);
   } else {
     // Handle other cases based on DOM element used as boundaries
     let boundariesNode;

--- a/src/positioning/utils/getViewportOffsetRectRelativeToArbitraryNode.ts
+++ b/src/positioning/utils/getViewportOffsetRectRelativeToArbitraryNode.ts
@@ -3,7 +3,7 @@ import { getOffsetRectRelativeToArbitraryNode } from './getOffsetRectRelativeToA
 import { getScroll } from './getScroll';
 import { Offsets } from '../models';
 
-export function getViewportOffsetRectRelativeToArtbitraryNode(element: HTMLElement, excludeScroll = false): Offsets {
+export function getViewportOffsetRectRelativeToArbitraryNode(element: HTMLElement, excludeScroll = false): Offsets {
   const html = element.ownerDocument.documentElement;
   const relativeOffset = getOffsetRectRelativeToArbitraryNode(element, html);
   const width = Math.max(html.clientWidth, window.innerWidth || 0);


### PR DESCRIPTION
## Summary

Fix a spelling mistake, renaming `getViewportOffsetRectRelativeToArtbitraryNode` to `getViewportOffsetRectRelativeToArbitraryNode` (note the missing `t` in 'Arbitrary').

## Breaking Change

The `getViewportOffsetRectRelativeToArtbitraryNode` function has been renamed to `getViewportOffsetRectRelativeToArbitraryNode`.

## PR Checklist

Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated tests
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.

_I could not find any mention to that function in the last three points_

## Note to Reviewers

I have marked this as a breaking change in case the function is exported publicly and/or intended to be used by downstream libraries. Having said that, it seems like this function is only used internally, so I'll leave it up to you to determine whether this qualifies as a breaking change or not.